### PR TITLE
Don't use subscriptions for 8.4

### DIFF
--- a/openstack/rhel-8.4-x86_64/config.json
+++ b/openstack/rhel-8.4-x86_64/config.json
@@ -2,5 +2,6 @@
     "user": "cloud-user",
     "runnerArch": "amd64",
     "maxInstances": 2,
-    "subscriptionNeeded": true
+    "subscriptionNeeded": false,
+    "nightlyRepoVarName": "RHEL84_NIGHTLY_REPO"
 }


### PR DESCRIPTION
because that fails when the distro hasn't been released yet.
Instead configure the nightlyRepoVarName attribute!

Designed to work with
https://github.com/osbuild/gitlab-ci-terraform-executor/pull/2