### PR TITLE
Rename nightly repo: redhat.repo -> rhel8internal.repo

### DIFF
--- a/aws/rhel-8.4-aarch64/config.json
+++ b/aws/rhel-8.4-aarch64/config.json
@@ -1,5 +1,5 @@
 {
     "user": "ec2-user",
     "runnerArch": "aarch64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/redhat.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }

--- a/aws/rhel-8.4-x86_64/config.json
+++ b/aws/rhel-8.4-x86_64/config.json
@@ -1,5 +1,5 @@
 {
     "user": "ec2-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/redhat.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }


### PR DESCRIPTION
because we have override logic that makes it possible to test an
arbitrary compose. While installing gitlab-ci-runner may be pulling
dependencies from the latest nightly we'd like for the remaining
duration of the test job and installation of osbuild-composer the
repositories to point to the chosen distro under test and make sure
we can override the values if necessary.

See
https://github.com/osbuild/osbuild-composer/blob/main/schutzbot/prepare-rhel-internal.sh