### PR TITLE
aws/rhel8.5: remove RHUI repos

### DIFF
--- a/aws/rhel-8.5-aarch64/config.json
+++ b/aws/rhel-8.5-aarch64/config.json
@@ -1,5 +1,5 @@
 {
     "user": "ec2-user",
     "runnerArch": "aarch64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm /etc/yum.repos.d/redhat-rhui* && sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }

--- a/aws/rhel-8.5-x86_64/config.json
+++ b/aws/rhel-8.5-x86_64/config.json
@@ -1,5 +1,5 @@
 {
     "user": "ec2-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm /etc/yum.repos.d/redhat-rhui* && sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }


### PR DESCRIPTION
RHEL 8.5 nightly images expect RHUI Beta to exist. They don't exist though.
Let's remove them.