### PR TITLE
aws: add RHEL 9.0 Beta runners

### DIFF
--- a/aws/rhel-9.0-beta-nightly-aarch64/config.json
+++ b/aws/rhel-9.0-beta-nightly-aarch64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "aarch64",
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+}

--- a/aws/rhel-9.0-beta-nightly-aarch64/main.tf
+++ b/aws/rhel-9.0-beta-nightly-aarch64/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-9.0-beta-nightly-aarch64"
+  ami              = "ami-099baba1ab528c769"
+  instance_type    = "c6g.large"
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}

--- a/aws/rhel-9.0-beta-nightly-x86_64/config.json
+++ b/aws/rhel-9.0-beta-nightly-x86_64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+}

--- a/aws/rhel-9.0-beta-nightly-x86_64/main.tf
+++ b/aws/rhel-9.0-beta-nightly-x86_64/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-9.0-beta-nightly-x86_64"
+  ami              = "ami-059cb6322aa611bcd"
+  instance_type    = "c5.large"
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}


### PR DESCRIPTION
Note that the RHUI workaround from 8.5 isn't needed because we're using
the guest image instead of the EC2 image (it doesn't exist yet).
This also means that the user is cloud-user instead ec2-user