### PR TITLE
Increase Openstack runner limit

### DIFF
--- a/openstack/centos-stream-8-x86_64/config.json
+++ b/openstack/centos-stream-8-x86_64/config.json
@@ -1,5 +1,5 @@
 {
     "user": "centos",
     "runnerArch": "amd64",
-    "maxInstances": 4
+    "maxInstances": 6
 }

--- a/openstack/fedora-33-x86_64/config.json
+++ b/openstack/fedora-33-x86_64/config.json
@@ -1,5 +1,5 @@
 {
     "user": "fedora",
     "runnerArch": "amd64",
-    "maxInstances": 4
+    "maxInstances": 6
 }

--- a/openstack/rhel-8-x86_64/config.json
+++ b/openstack/rhel-8-x86_64/config.json
@@ -1,6 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "maxInstances": 4,
+    "maxInstances": 6,
     "subscriptionNeeded": true
 }

--- a/openstack/rhel-8.4-x86_64/config.json
+++ b/openstack/rhel-8.4-x86_64/config.json
@@ -1,6 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "maxInstances": 2,
+    "maxInstances": 6,
     "prepareScript": "sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.4.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }

--- a/openstack/rhel-8.5-x86_64/config.json
+++ b/openstack/rhel-8.5-x86_64/config.json
@@ -1,6 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "maxInstances": 2,
+    "maxInstances": 6,
     "prepareScript": "sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }


### PR DESCRIPTION
There are jobs waiting for Openstack runner for over 2 hours at times
and looking at the Openstack project we're using only a 1/4 of the
limits.