### PR TITLE
aws: use bigger disks

### DIFF
--- a/aws/_base/main.tf
+++ b/aws/_base/main.tf
@@ -29,6 +29,6 @@ resource "aws_spot_instance_request" "runner" {
     Name = var.name
   }
   root_block_device {
-    volume_size = 20
+    volume_size = 40
   }
 }


### PR DESCRIPTION
20 GB is apparently not enough for RHEL 9.0 beta base tests, let's
bump it to 40 GB.

Fixes osbuild/osbuild-composer#1718