### PR TITLE
openstack: update rhel-9 guest images

### DIFF
--- a/openstack/rhel-9.0-beta-nightly-x86_64/main.tf
+++ b/openstack/rhel-9.0-beta-nightly-x86_64/main.tf
@@ -2,7 +2,7 @@ module "openstack" {
   source = "../_base"
 
   name     = "rhel-9-0-beta-nightly"
-  image_id = "43a68379-5468-490d-a51a-141ce33f9165"
+  image_id = "c332bd07-2b10-4de9-9090-736e904d09a8"
 }
 
 output "ip_address" {


### PR DESCRIPTION
There seems to be the same problem like we had with aws rhel-9
guest images, so updating in openstack as well.

Here's a failing run: https://gitlab.com/osbuild/ci/osbuild-composer/-/jobs/1557167393
Passing run with the new image: https://gitlab.com/osbuild/ci/osbuild-composer/-/jobs/1557493407