### PR TITLE
aws/fedora-33: Update libmodulemd in prepare

### DIFF
--- a/aws/fedora-33-aarch64/config.json
+++ b/aws/fedora-33-aarch64/config.json
@@ -1,4 +1,5 @@
 {
     "user": "fedora",
-    "runnerArch": "aarch64"
+    "runnerArch": "aarch64",
+    "prepareScript": "sudo dnf update -y libmodulemd"
 }

--- a/aws/fedora-33-x86_64/config.json
+++ b/aws/fedora-33-x86_64/config.json
@@ -1,4 +1,5 @@
 {
     "user": "fedora",
-    "runnerArch": "amd64"
+    "runnerArch": "amd64",
+    "prepareScript": "sudo dnf update -y libmodulemd"
 }


### PR DESCRIPTION
Needed to recognize `static_context` in metadata. Mitigates
https://pagure.io/fedora-infrastructure/issue/10220.