### PR TITLE
openstack/fedora-33: Update libmodulemd in prepare

### DIFF
--- a/openstack/fedora-33-x86_64/config.json
+++ b/openstack/fedora-33-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "fedora",
     "runnerArch": "amd64",
-    "maxInstances": 6
+    "maxInstances": 6,
+    "prepareScript": "sudo dnf update -y libmodulemd"
 }


### PR DESCRIPTION
Needed to recognize `static_context` in metadata. Mitigates
https://pagure.io/fedora-infrastructure/issue/10220.