### PR TITLE
aws: update RHEL 8.6 runners

### DIFF
--- a/aws/rhel-8.6-nightly-aarch64/main.tf
+++ b/aws/rhel-8.6-nightly-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "rhel-8.6-nightly-aarch64"
-  ami              = "ami-07a7b2743746ddf9c"
+  ami              = "ami-084fa679de68f1912"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
 }

--- a/aws/rhel-8.6-nightly-x86_64/main.tf
+++ b/aws/rhel-8.6-nightly-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "rhel-8.6-nightly-x86_64"
-  ami              = "ami-046d2071ebdf191c9"
+  ami              = "ami-0767af0854a146e3e"
   instance_type    = "c5.large"
   internal_network = var.internal_network
 }


### PR DESCRIPTION
Previous AMIs were not working.  I tested these new ones in the devel account before sharing.