### PR TITLE
*/rhel-9.0-beta*: use an older compose to work around an rpm size issue

### DIFF
--- a/aws/rhel-9.0-beta-nightly-aarch64/config.json
+++ b/aws/rhel-9.0-beta-nightly-aarch64/config.json
@@ -1,5 +1,5 @@
 {
     "user": "cloud-user",
     "runnerArch": "aarch64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }

--- a/aws/rhel-9.0-beta-nightly-x86_64/config.json
+++ b/aws/rhel-9.0-beta-nightly-x86_64/config.json
@@ -1,5 +1,5 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }

--- a/openstack/rhel-9.0-beta-nightly-x86_64/config.json
+++ b/openstack/rhel-9.0-beta-nightly-x86_64/config.json
@@ -2,5 +2,5 @@
     "user": "cloud-user",
     "runnerArch": "amd64",
     "maxInstances": 6,
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/RHEL-9.0.0-20211017.6/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }


### PR DESCRIPTION
See RHELCMP-7135