### PR TITLE
Add RHEL 9.0 runners

### DIFF
--- a/aws/rhel-9.0-nightly-aarch64/config.json
+++ b/aws/rhel-9.0-nightly-aarch64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "aarch64",
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+}

--- a/aws/rhel-9.0-nightly-aarch64/main.tf
+++ b/aws/rhel-9.0-nightly-aarch64/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-9.0-nightly-aarch64"
+  ami              = "ami-0ace03b630093437d"
+  instance_type    = "c6g.large"
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}

--- a/aws/rhel-9.0-nightly-x86_64/config.json
+++ b/aws/rhel-9.0-nightly-x86_64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+}

--- a/aws/rhel-9.0-nightly-x86_64/main.tf
+++ b/aws/rhel-9.0-nightly-x86_64/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-9.0-nightly-x86_64"
+  ami              = "ami-08899a70831c08ddd"
+  instance_type    = "c5.large"
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}

--- a/openstack/rhel-9.0-nightly-x86_64-large/config.json
+++ b/openstack/rhel-9.0-nightly-x86_64-large/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "maxInstances": 6,
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+}

--- a/openstack/rhel-9.0-nightly-x86_64-large/main.tf
+++ b/openstack/rhel-9.0-nightly-x86_64-large/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "rhel-9-0"
+  image_id  = "62b49be2-e9c6-46c2-b1bb-37e646ac87ed"
+  flavor_id = "4b04b7c3-ec50-469f-9c07-c41f0bff4972"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}

--- a/openstack/rhel-9.0-nightly-x86_64/config.json
+++ b/openstack/rhel-9.0-nightly-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "maxInstances": 6,
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+}

--- a/openstack/rhel-9.0-nightly-x86_64/main.tf
+++ b/openstack/rhel-9.0-nightly-x86_64/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "rhel-9-0-nightly"
+  image_id  = "62b49be2-e9c6-46c2-b1bb-37e646ac87ed"
+  flavor_id = "893c20cf-d5ea-4c7d-9eee-2bc4b3e5723e"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}


### PR DESCRIPTION
Added runners for RHEL 9.0 (non-beta)
- AWS x86_64
- AWS aarch64
- Openstack x86_64
- Openstack x86_64 Large

Signed-off-by: Achilleas Koutsou <achilleas@koutsou.net>