### PR TITLE
aws: replace c5.large with c6i.large

### DIFF
--- a/aws/centos-stream-8-x86_64/main.tf
+++ b/aws/centos-stream-8-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-8-x86_64"
   ami              = "ami-059f1cc52e6c85908"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-33-x86_64/main.tf
+++ b/aws/fedora-33-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-33-x86_64"
   ami              = "ami-01efb339f953fdf36"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-34-x86_64/main.tf
+++ b/aws/fedora-34-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-34-x86_64"
   ami              = "ami-00da07c8f705da39b"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8-x86_64/main.tf
+++ b/aws/rhel-8-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8-x86_64"
   ami              = "ami-038fd6fce9aaf122f"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.4-ga-x86_64/main.tf
+++ b/aws/rhel-8.4-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.4-ga-x86_64"
   ami              = "ami-0ae9702360611e715"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.5-ga-x86_64/main.tf
+++ b/aws/rhel-8.5-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.5-ga-x86_64"
   ami              = "ami-06f1e6f8b3457ae7c"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.5-nightly-x86_64/main.tf
+++ b/aws/rhel-8.5-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.5-nightly-x86_64"
   ami              = "ami-0c14d21e741b97c48"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.6-nightly-x86_64/main.tf
+++ b/aws/rhel-8.6-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.6-nightly-x86_64"
   ami              = "ami-0767af0854a146e3e"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.0-beta-nightly-x86_64/main.tf
+++ b/aws/rhel-9.0-beta-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.0-beta-nightly-x86_64"
   ami              = "ami-0bfad1ec951eb7bd7"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.0-nightly-x86_64/main.tf
+++ b/aws/rhel-9.0-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.0-nightly-x86_64"
   ami              = "ami-08899a70831c08ddd"
-  instance_type    = "c5.large"
+  instance_type    = "c6i.large"
   internal_network = var.internal_network
 }
 


### PR DESCRIPTION
By my measurements, c6i.large is faster by 10% for the same price.