### PR TITLE
aws,openstack/centos-9: fix user names

### DIFF
--- a/aws/centos-stream-9-aarch64/config.json
+++ b/aws/centos-stream-9-aarch64/config.json
@@ -1,4 +1,4 @@
 {
-    "user": "centos",
+    "user": "ec2-user",
     "runnerArch": "aarch64"
 }

--- a/aws/centos-stream-9-x86_64/config.json
+++ b/aws/centos-stream-9-x86_64/config.json
@@ -1,4 +1,4 @@
 {
-    "user": "centos",
+    "user": "ec2-user",
     "runnerArch": "amd64"
 }

--- a/openstack/centos-stream-9-x86_64-large/config.json
+++ b/openstack/centos-stream-9-x86_64-large/config.json
@@ -1,5 +1,5 @@
 {
-    "user": "centos",
+    "user": "cloud-user",
     "runnerArch": "amd64",
     "maxInstances": 6
 }

--- a/openstack/centos-stream-9-x86_64/config.json
+++ b/openstack/centos-stream-9-x86_64/config.json
@@ -1,5 +1,5 @@
 {
-    "user": "centos",
+    "user": "cloud-user",
     "runnerArch": "amd64",
     "maxInstances": 6
 }


### PR DESCRIPTION
For openstack, the images were created with the default "cloud-user".
For AWS, the images were created with "ec2-user".