### PR TITLE
Add CS9 runners to RHOS-01

### DIFF
--- a/aws/centos-stream-9-aarch64/config.json
+++ b/aws/centos-stream-9-aarch64/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "centos",
+    "runnerArch": "aarch64"
+}

--- a/aws/centos-stream-9-aarch64/config.json
+++ b/aws/centos-stream-9-aarch64/config.json
@@ -1,4 +1,4 @@
 {
-    "user": "centos",
+    "user": "ec2-user",
     "runnerArch": "aarch64"
 }

--- a/aws/centos-stream-9-aarch64/main.tf
+++ b/aws/centos-stream-9-aarch64/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "centos-stream-9-aarch64"
+  ami              = "ami-08751d099be28f086"
+  instance_type    = "c6g.large"
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}

--- a/aws/centos-stream-9-x86_64/config.json
+++ b/aws/centos-stream-9-x86_64/config.json
@@ -1,4 +1,4 @@
 {
-    "user": "centos",
+    "user": "ec2-user",
     "runnerArch": "amd64"
 }

--- a/aws/centos-stream-9-x86_64/config.json
+++ b/aws/centos-stream-9-x86_64/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "centos",
+    "runnerArch": "amd64"
+}

--- a/aws/centos-stream-9-x86_64/main.tf
+++ b/aws/centos-stream-9-x86_64/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "centos-stream-9-x86_64"
+  ami              = "ami-09d21608cdeb79c49"
+  instance_type    = "c6i.large"
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}

--- a/openstack/centos-stream-9-x86_64-large/config.json
+++ b/openstack/centos-stream-9-x86_64-large/config.json
@@ -1,5 +1,5 @@
 {
-    "user": "centos",
+    "user": "cloud-user",
     "runnerArch": "amd64",
     "maxInstances": 6
 }

--- a/openstack/centos-stream-9-x86_64-large/config.json
+++ b/openstack/centos-stream-9-x86_64-large/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "centos",
+    "runnerArch": "amd64",
+    "maxInstances": 6
+}

--- a/openstack/centos-stream-9-x86_64-large/main.tf
+++ b/openstack/centos-stream-9-x86_64-large/main.tf
@@ -2,8 +2,8 @@ module "openstack" {
   source = "../_base"
 
   name      = "centos-stream-9"
-  image_id  = "cbde2b13-c019-4197-9bf2-ceadee6b0c77"
-  flavor_id = "4b04b7c3-ec50-469f-9c07-c41f0bff4972"
+  image_id  = "e9f71aa2-79ab-4ee0-8a38-296395751261"
+  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
 }
 
 output "ip_address" {

--- a/openstack/centos-stream-9-x86_64-large/main.tf
+++ b/openstack/centos-stream-9-x86_64-large/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "centos-stream-9"
+  image_id  = "cbde2b13-c019-4197-9bf2-ceadee6b0c77"
+  flavor_id = "4b04b7c3-ec50-469f-9c07-c41f0bff4972"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}

--- a/openstack/centos-stream-9-x86_64/config.json
+++ b/openstack/centos-stream-9-x86_64/config.json
@@ -1,5 +1,5 @@
 {
-    "user": "centos",
+    "user": "cloud-user",
     "runnerArch": "amd64",
     "maxInstances": 6
 }

--- a/openstack/centos-stream-9-x86_64/config.json
+++ b/openstack/centos-stream-9-x86_64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "centos",
+    "runnerArch": "amd64",
+    "maxInstances": 6
+}

--- a/openstack/centos-stream-9-x86_64/main.tf
+++ b/openstack/centos-stream-9-x86_64/main.tf
@@ -2,8 +2,8 @@ module "openstack" {
   source = "../_base"
 
   name      = "centos-stream-9"
-  image_id  = "cbde2b13-c019-4197-9bf2-ceadee6b0c77"
-  flavor_id = "893c20cf-d5ea-4c7d-9eee-2bc4b3e5723e"
+  image_id  = "e9f71aa2-79ab-4ee0-8a38-296395751261"
+  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
 }
 
 output "ip_address" {

--- a/openstack/centos-stream-9-x86_64/main.tf
+++ b/openstack/centos-stream-9-x86_64/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "centos-stream-9"
+  image_id  = "cbde2b13-c019-4197-9bf2-ceadee6b0c77"
+  flavor_id = "893c20cf-d5ea-4c7d-9eee-2bc4b3e5723e"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}


### PR DESCRIPTION
Cherry picked commits from `main` to get the CS9 runners into the `rhos-01` branch.
Updated the `flavor-id`s for the openstack CS9 runners accordingly.