### PR TITLE
aws: set max provider version to 3.72.0

### DIFF
--- a/aws/_base/main.tf
+++ b/aws/_base/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 3.72.0"
     }
   }
 }


### PR DESCRIPTION
We cannont provision AWS runners with newer version due to some
permission issues with VPC. This seems to be latest working version so
hard-coding it now to unblock CI.