### PR TITLE
Add centos-stream-8-x86_64-large runner

### DIFF
--- a/rhos-01/centos-stream-8-x86_64-large/config.json
+++ b/rhos-01/centos-stream-8-x86_64-large/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "centos",
+    "runnerArch": "amd64"
+}

--- a/rhos-01/centos-stream-8-x86_64-large/main.tf
+++ b/rhos-01/centos-stream-8-x86_64-large/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "centos-stream-8"
+  image_id  = "0285b667-3d71-4e8d-a66d-a0442bae9116"
+  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}


### PR DESCRIPTION
RHEL 8.6 has a `large` runner to run ostree tests, so CS8 runner needs the same `large` runner as well.