### PR TITLE
aws: allow to specify internal subnet via variable

### DIFF
--- a/aws/_base/main.tf
+++ b/aws/_base/main.tf
@@ -19,7 +19,7 @@ resource "aws_spot_instance_request" "runner" {
   wait_for_fulfillment = true
   spot_type            = "one-time"
 
-  subnet_id = var.internal_network ? data.aws_subnet.internal_subnet_primary.id : data.aws_subnet.external_subnet_primary.id
+  subnet_id = var.internal_network ? "${var.internal_subnet == "" ? data.aws_subnet.internal_subnet_primary.id : var.internal_subnet}" : data.aws_subnet.external_subnet_primary.id
 
   vpc_security_group_ids = [
     var.internal_network ? data.aws_security_group.internal_security_group.id : data.aws_security_group.external_security_group.id

--- a/aws/_base/variables.tf
+++ b/aws/_base/variables.tf
@@ -17,3 +17,8 @@ variable "internal_network" {
   description = "Whether this instance should be in the internal network."
   type        = bool
 }
+
+variable "internal_subnet" {
+  description = "ID of an internal subnet"
+  type        = string
+}

--- a/aws/centos-stream-8-aarch64/main.tf
+++ b/aws/centos-stream-8-aarch64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-0a311be1169cd6581"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/centos-stream-8-x86_64/main.tf
+++ b/aws/centos-stream-8-x86_64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-059f1cc52e6c85908"
   instance_type    = "c6i.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/centos-stream-9-aarch64/main.tf
+++ b/aws/centos-stream-9-aarch64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-08751d099be28f086"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/centos-stream-9-x86_64/main.tf
+++ b/aws/centos-stream-9-x86_64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-09d21608cdeb79c49"
   instance_type    = "c6i.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/fedora-34-aarch64/main.tf
+++ b/aws/fedora-34-aarch64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-024947169ddaaf965"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/fedora-34-x86_64/main.tf
+++ b/aws/fedora-34-x86_64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-00da07c8f705da39b"
   instance_type    = "c6i.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/fedora-35-aarch64/main.tf
+++ b/aws/fedora-35-aarch64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-068c123e1c1ca0d49"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/fedora-35-x86_64/main.tf
+++ b/aws/fedora-35-x86_64/main.tf
@@ -9,6 +9,7 @@ module "aws" {
   # TODO for Fedora 36: update this to c6i.large for more performance
   instance_type    = "c5a.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -19,4 +20,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/rhel-8.4-ga-aarch64/main.tf
+++ b/aws/rhel-8.4-ga-aarch64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-0297f1f9bad64fa3d"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/rhel-8.4-ga-x86_64/main.tf
+++ b/aws/rhel-8.4-ga-x86_64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-0ae9702360611e715"
   instance_type    = "c6i.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/rhel-8.5-ga-aarch64/main.tf
+++ b/aws/rhel-8.5-ga-aarch64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-06bbacb93891d7356"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/rhel-8.5-ga-x86_64/main.tf
+++ b/aws/rhel-8.5-ga-x86_64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-06f1e6f8b3457ae7c"
   instance_type    = "c6i.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/rhel-8.6-nightly-aarch64/main.tf
+++ b/aws/rhel-8.6-nightly-aarch64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-084fa679de68f1912"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/rhel-8.6-nightly-x86_64/main.tf
+++ b/aws/rhel-8.6-nightly-x86_64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-0767af0854a146e3e"
   instance_type    = "c6i.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,16 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/rhel-9.0-nightly-aarch64/main.tf
+++ b/aws/rhel-9.0-nightly-aarch64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-0ace03b630093437d"
   instance_type    = "c6g.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }

--- a/aws/rhel-9.0-nightly-x86_64/main.tf
+++ b/aws/rhel-9.0-nightly-x86_64/main.tf
@@ -5,6 +5,7 @@ module "aws" {
   ami              = "ami-08899a70831c08ddd"
   instance_type    = "c6i.large"
   internal_network = var.internal_network
+  internal_subnet  = var.internal_subnet
 }
 
 variable "internal_network" {
@@ -15,4 +16,10 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "internal_subnet" {
+  description = "Which internal subnet to use."
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
This allows to supply the subnet ID as an external variable. The
variable is optional and in case it's not supplied, it works like before
which is just taking the first subnet ID from aws.

Required for https://github.com/osbuild/gitlab-ci-terraform-executor/pull/11