### PR TITLE
Add fedora-35-x86_64-large as ostree-ng.sh runner

### DIFF
--- a/rhos-01/fedora-35-x86_64-large/config.json
+++ b/rhos-01/fedora-35-x86_64-large/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "fedora",
+    "runnerArch": "amd64"
+}

--- a/rhos-01/fedora-35-x86_64-large/main.tf
+++ b/rhos-01/fedora-35-x86_64-large/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "fedora-35"
+  image_id  = "d62a2182-947b-421e-b3db-9b55b4dda522"
+  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}


### PR DESCRIPTION
To run ostree-ng.sh, a "large" runner is required. https://github.com/osbuild/osbuild-composer/pull/2461 needs this PR.