### PR TITLE
aws: introduce RHEL 8.6 and 9.0 metal instances

### DIFF
--- a/aws/rhel-8.6-nightly-x86_64-metal/config.json
+++ b/aws/rhel-8.6-nightly-x86_64-metal/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+}

--- a/aws/rhel-8.6-nightly-x86_64-metal/main.tf
+++ b/aws/rhel-8.6-nightly-x86_64-metal/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-8.6-nightly-x86_64"
+  ami              = "ami-0767af0854a146e3e"
+  instance_type    = "c6i.metal"
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}

--- a/aws/rhel-9.0-nightly-x86_64-metal/config.json
+++ b/aws/rhel-9.0-nightly-x86_64-metal/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+}

--- a/aws/rhel-9.0-nightly-x86_64-metal/main.tf
+++ b/aws/rhel-9.0-nightly-x86_64-metal/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-9.0-nightly-x86_64"
+  ami              = "ami-08899a70831c08ddd"
+  instance_type    = "c6i.metal"
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}


### PR DESCRIPTION
With the recent RH infra outages, we need a way to run our testsuite with
nested virtualization enabled. Let's introduce metal instances to this
repository.