### PR TITLE
aws: add fedora-36 runners

### DIFF
--- a/aws/fedora-36-aarch64/config.json
+++ b/aws/fedora-36-aarch64/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "fedora",
+    "runnerArch": "aarch64"
+}

--- a/aws/fedora-36-aarch64/main.tf
+++ b/aws/fedora-36-aarch64/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "fedora-36-aarch64"
+  ami              = "ami-01925eb0821988986"
+  instance_types   = ["c7g.large"]
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}

--- a/aws/fedora-36-x86_64/config.json
+++ b/aws/fedora-36-x86_64/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "fedora",
+    "runnerArch": "amd64"
+}

--- a/aws/fedora-36-x86_64/main.tf
+++ b/aws/fedora-36-x86_64/main.tf
@@ -1,0 +1,18 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "fedora-36-x86_64"
+  ami              = "ami-08b7bda26f4071b80"
+  instance_types   = ["c6i.large", "c6a.large"]
+  internal_network = var.internal_network
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}


### PR DESCRIPTION
I've tested the fedora-36 image on c6i.large and it booted just fine, was able to login and run dnf so I consider it working. Otherwise compared to fedora-35 I've just changed the amis