### PR TITLE
Switch to non ssd isntances on RHOS-01 and add c6g.large to aarch64 spot request

### DIFF
--- a/aws/centos-stream-8-aarch64/main.tf
+++ b/aws/centos-stream-8-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-8-aarch64"
   ami              = "ami-0a311be1169cd6581"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/centos-stream-9-aarch64/main.tf
+++ b/aws/centos-stream-9-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-9-aarch64"
   ami              = "ami-08751d099be28f086"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-35-aarch64/main.tf
+++ b/aws/fedora-35-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-35-aarch64"
   ami              = "ami-068c123e1c1ca0d49"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-36-aarch64/main.tf
+++ b/aws/fedora-36-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-36-aarch64"
   ami              = "ami-01925eb0821988986"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.4-ga-aarch64/main.tf
+++ b/aws/rhel-8.4-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.4-ga-aarch64"
   ami              = "ami-0297f1f9bad64fa3d"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.5-ga-aarch64/main.tf
+++ b/aws/rhel-8.5-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.5-ga-aarch64"
   ami              = "ami-06bbacb93891d7356"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.6-ga-aarch64/main.tf
+++ b/aws/rhel-8.6-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.6-ga-aarch64"
   ami              = "ami-0238411fb452f8275"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.7-nightly-aarch64/main.tf
+++ b/aws/rhel-8.7-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.7-nightly-aarch64"
   ami              = "ami-0d13b40991f03cc46"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.0-ga-aarch64/main.tf
+++ b/aws/rhel-9.0-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.0-ga-aarch64"
   ami              = "ami-08ddbe20d7e0d2f8f"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.1-nightly-aarch64/main.tf
+++ b/aws/rhel-9.1-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.1-nightly-aarch64"
   ami              = "ami-0d2f9b81e9ec5778e"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
 }
 

--- a/rhos-01/centos-stream-8-x86_64-large/main.tf
+++ b/rhos-01/centos-stream-8-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "centos-stream-8"
   image_id  = "0285b667-3d71-4e8d-a66d-a0442bae9116"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/centos-stream-8-x86_64/main.tf
+++ b/rhos-01/centos-stream-8-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "centos-stream-8"
   image_id  = "0285b667-3d71-4e8d-a66d-a0442bae9116"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/centos-stream-9-x86_64-large/main.tf
+++ b/rhos-01/centos-stream-9-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "centos-stream-9"
   image_id  = "9f49b07d-57e2-4998-a8e3-6d13457fde85"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/centos-stream-9-x86_64/main.tf
+++ b/rhos-01/centos-stream-9-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "centos-stream-9"
   image_id  = "9f49b07d-57e2-4998-a8e3-6d13457fde85"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/fedora-35-x86_64-large/main.tf
+++ b/rhos-01/fedora-35-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "fedora-35"
   image_id  = "d62a2182-947b-421e-b3db-9b55b4dda522"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/fedora-35-x86_64/main.tf
+++ b/rhos-01/fedora-35-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "fedora-35"
   image_id  = "d62a2182-947b-421e-b3db-9b55b4dda522"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/fedora-36-x86_64-large/main.tf
+++ b/rhos-01/fedora-36-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "fedora-36"
   image_id  = "60f5c075-936c-47b4-a00b-0cb6867ffd32"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/fedora-36-x86_64/main.tf
+++ b/rhos-01/fedora-36-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "fedora-36"
   image_id  = "60f5c075-936c-47b4-a00b-0cb6867ffd32"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-8.4-ga-x86_64/main.tf
+++ b/rhos-01/rhel-8.4-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-8-4-ga"
   image_id  = "d30f0336-745a-45b9-bc87-cf3489e42982"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-8.5-ga-x86_64-large/main.tf
+++ b/rhos-01/rhel-8.5-ga-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-8-5-ga-large"
   image_id  = "b3ddd447-18c5-4495-926b-5b5fdd269d16"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-8.5-ga-x86_64/main.tf
+++ b/rhos-01/rhel-8.5-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-8-5-ga"
   image_id  = "a99c9aa6-7a24-4c58-bded-92c4dc4e998a"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-8.5-x86_64-large/main.tf
+++ b/rhos-01/rhel-8.5-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-8-5"
   image_id  = "b3ddd447-18c5-4495-926b-5b5fdd269d16"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-8.6-ga-x86_64-large/main.tf
+++ b/rhos-01/rhel-8.6-ga-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-8-6-ga-large"
   image_id  = "18dee42a-e354-4a4d-9c2d-851540dfed25"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-8.6-ga-x86_64/main.tf
+++ b/rhos-01/rhel-8.6-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-8-6-ga"
   image_id  = "18dee42a-e354-4a4d-9c2d-851540dfed25"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-8.7-nightly-x86_64-large/main.tf
+++ b/rhos-01/rhel-8.7-nightly-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-8-7-nightly-large"
   image_id  = "27dd121f-1512-4c1d-bed5-a717c7d5c9e2"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-8.7-nightly-x86_64/main.tf
+++ b/rhos-01/rhel-8.7-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-8-7-nightly"
   image_id  = "27dd121f-1512-4c1d-bed5-a717c7d5c9e2"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-9.0-ga-x86_64-large/main.tf
+++ b/rhos-01/rhel-9.0-ga-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-9-0"
   image_id  = "debe655a-cc93-4f42-9d1e-23b81b2d08c4"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-9.0-ga-x86_64/main.tf
+++ b/rhos-01/rhel-9.0-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-9-0-ga"
   image_id  = "debe655a-cc93-4f42-9d1e-23b81b2d08c4"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-9.1-nightly-x86_64-large/main.tf
+++ b/rhos-01/rhel-9.1-nightly-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-9-1"
   image_id  = "ea4d8610-5125-4f07-aba0-4bf8bd7c9622"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/rhel-9.1-nightly-x86_64/main.tf
+++ b/rhos-01/rhel-9.1-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "rhel-9-1-nightly"
   image_id  = "ea4d8610-5125-4f07-aba0-4bf8bd7c9622"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {


### PR DESCRIPTION
We've been using non ssd instances for over a month on RHOS-01 Openstack so I think it's fine to merge it to main.

Lately there were occasions where there were no aarch runners available so let's add an option to also use c6g.large instance.