### PR TITLE
More instance type options for Fedora-35

### DIFF
--- a/aws/fedora-35-x86_64/main.tf
+++ b/aws/fedora-35-x86_64/main.tf
@@ -7,7 +7,7 @@ module "aws" {
   # Fedora 35 AMI doesn't boot on c6i.large, let's use only AMD
   # See: https://pagure.io/cloud-sig/issue/359
   # TODO for Fedora 36: add c6i.large for more options
-  instance_types   = ["c6a.large"]
+  instance_types   = ["c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 


### PR DESCRIPTION
    Fedora-35 became almost impossible to provision in the CI, adding more
    instance types to fix that.
