### PR TITLE
aws/fedora-37: remove all repos during provisioning

### DIFF
--- a/aws/fedora-37-aarch64/config.json
+++ b/aws/fedora-37-aarch64/config.json
@@ -1,4 +1,5 @@
 {
     "user": "fedora",
-    "runnerArch": "aarch64"
+    "runnerArch": "aarch64",
+    "prepareScript": "sudo rm -rf /etc/yum.repos.d/*.repo"
 }

--- a/aws/fedora-37-x86_64/config.json
+++ b/aws/fedora-37-x86_64/config.json
@@ -1,4 +1,5 @@
 {
     "user": "fedora",
-    "runnerArch": "amd64"
+    "runnerArch": "amd64",
+    "prepareScript": "sudo rm -rf /etc/yum.repos.d/*.repo"
 }


### PR DESCRIPTION
The updates-testing repository is enabled in the ami by default and since we don't snapshot that repository we don't overwrite it with our snapshot and this is causing issues in CI.