### PR TITLE
openstack/fedora-37: remove all repos during provisioning

### DIFF
--- a/rhos-01/fedora-37-x86_64-large/config.json
+++ b/rhos-01/fedora-37-x86_64-large/config.json
@@ -1,4 +1,5 @@
 {
     "user": "fedora",
-    "runnerArch": "amd64"
+    "runnerArch": "amd64",
+    "prepareScript": "sudo rm -rf /etc/yum.repos.d/*.repo"
 }

--- a/rhos-01/fedora-37-x86_64/config.json
+++ b/rhos-01/fedora-37-x86_64/config.json
@@ -1,4 +1,5 @@
 {
     "user": "fedora",
-    "runnerArch": "amd64"
+    "runnerArch": "amd64",
+    "prepareScript": "sudo rm -rf /etc/yum.repos.d/*.repo"
 }


### PR DESCRIPTION
The updates-testing repository is apparently enabled in all of the fedora-37 images by default and since we don't snapshot that repository we don't overwrite it with our snapshot and this is causing issues in CI.