### PR TITLE
aws: add c5 isntances for more spot options

### DIFF
--- a/aws/centos-stream-8-x86_64/main.tf
+++ b/aws/centos-stream-8-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-8-x86_64"
   ami              = "ami-059f1cc52e6c85908"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/centos-stream-9-x86_64/main.tf
+++ b/aws/centos-stream-9-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-9-x86_64"
   ami              = "ami-0ac40768a045a5f2b"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-36-x86_64/main.tf
+++ b/aws/fedora-36-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-36-x86_64"
   ami              = "ami-08b7bda26f4071b80"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-37-x86_64/main.tf
+++ b/aws/fedora-37-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-37-x86_64"
   ami              = "ami-0bebd838a57335c31"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.4-ga-x86_64/main.tf
+++ b/aws/rhel-8.4-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.4-ga-x86_64"
   ami              = "ami-0ae9702360611e715"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.5-ga-x86_64/main.tf
+++ b/aws/rhel-8.5-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.5-ga-x86_64"
   ami              = "ami-06f1e6f8b3457ae7c"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.6-ga-x86_64/main.tf
+++ b/aws/rhel-8.6-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.6-ga-x86_64"
   ami              = "ami-06640050dc3f556bb"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.7-nightly-x86_64/main.tf
+++ b/aws/rhel-8.7-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.7-nightly-x86_64"
   ami              = "ami-0e85834babf34f9f1"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.8-nightly-x86_64/main.tf
+++ b/aws/rhel-8.8-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.8-nightly-x86_64"
   ami              = "ami-02ae1f6cd70c7b0b8"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.0-ga-x86_64/main.tf
+++ b/aws/rhel-9.0-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.0-ga-x86_64"
   ami              = "ami-0c41531b8d18cc72b"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.1-nightly-x86_64/main.tf
+++ b/aws/rhel-9.1-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.1-nightly-x86_64"
   ami              = "ami-044006978614b7d8d"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.2-nightly-x86_64/main.tf
+++ b/aws/rhel-9.2-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.2-nightly-x86_64"
   ami              = "ami-0b8c9fa46efa586f8"
-  instance_types   = ["c6i.large", "c6a.large"]
+  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
 }
 


### PR DESCRIPTION
c6 instances are not as available as before, add c5 to fill the gaps.