### PR TITLE
aws/tags: add a new set of tags to AWS instances

### DIFF
--- a/aws/_base/main.tf
+++ b/aws/_base/main.tf
@@ -38,7 +38,13 @@ resource "aws_spot_fleet_request" "runner" {
       }
 
       tags = {
-        Name = "Schutzbot runner"
+        Name            = "Schutzbot runner"
+        Workload        = "CI Runner"
+        Job_name        = var.job_name
+        Project         = var.project
+        Branch          = var.branch
+        Pipeline_id     = var.pipeline_id
+        Pipeline_source = var.pipeline_source
       }
     }
   }

--- a/aws/_base/variables.tf
+++ b/aws/_base/variables.tf
@@ -17,3 +17,28 @@ variable "internal_network" {
   description = "Whether this instance should be in the internal network."
   type        = bool
 }
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+}
+
+variable "pipeline_source" {
+  description = "the source that triggered the job"
+  type        = string
+}

--- a/aws/centos-stream-8-aarch64/main.tf
+++ b/aws/centos-stream-8-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0a311be1169cd6581"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/centos-stream-8-x86_64/main.tf
+++ b/aws/centos-stream-8-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-059f1cc52e6c85908"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/centos-stream-9-aarch64/main.tf
+++ b/aws/centos-stream-9-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-08751d099be28f086"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/centos-stream-9-x86_64/main.tf
+++ b/aws/centos-stream-9-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0ac40768a045a5f2b"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/fedora-35-aarch64/main.tf
+++ b/aws/fedora-35-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-068c123e1c1ca0d49"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/fedora-35-x86_64/main.tf
+++ b/aws/fedora-35-x86_64/main.tf
@@ -9,6 +9,11 @@ module "aws" {
   # TODO for Fedora 36: add c6i.large for more options
   instance_types   = ["c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -19,4 +24,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/fedora-36-aarch64/main.tf
+++ b/aws/fedora-36-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-01925eb0821988986"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/fedora-36-x86_64/main.tf
+++ b/aws/fedora-36-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-08b7bda26f4071b80"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/fedora-37-aarch64/main.tf
+++ b/aws/fedora-37-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-01bd3f31f182f38fc"
   instance_types   = ["c7g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/fedora-37-x86_64/main.tf
+++ b/aws/fedora-37-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0bebd838a57335c31"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.4-ga-aarch64/main.tf
+++ b/aws/rhel-8.4-ga-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0297f1f9bad64fa3d"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.4-ga-x86_64/main.tf
+++ b/aws/rhel-8.4-ga-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0ae9702360611e715"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.5-ga-aarch64/main.tf
+++ b/aws/rhel-8.5-ga-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-06bbacb93891d7356"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.5-ga-x86_64/main.tf
+++ b/aws/rhel-8.5-ga-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-06f1e6f8b3457ae7c"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.6-ga-aarch64/main.tf
+++ b/aws/rhel-8.6-ga-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0238411fb452f8275"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.6-ga-x86_64/main.tf
+++ b/aws/rhel-8.6-ga-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-06640050dc3f556bb"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.7-nightly-aarch64/main.tf
+++ b/aws/rhel-8.7-nightly-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0d13b40991f03cc46"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.7-nightly-x86_64/main.tf
+++ b/aws/rhel-8.7-nightly-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0e85834babf34f9f1"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.8-nightly-aarch64/main.tf
+++ b/aws/rhel-8.8-nightly-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-028ae4e81828fd7a9"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-8.8-nightly-x86_64/main.tf
+++ b/aws/rhel-8.8-nightly-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-02ae1f6cd70c7b0b8"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-9.0-ga-aarch64/main.tf
+++ b/aws/rhel-9.0-ga-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-08ddbe20d7e0d2f8f"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-9.0-ga-x86_64/main.tf
+++ b/aws/rhel-9.0-ga-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0c41531b8d18cc72b"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-9.1-nightly-aarch64/main.tf
+++ b/aws/rhel-9.1-nightly-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0d2f9b81e9ec5778e"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-9.1-nightly-x86_64/main.tf
+++ b/aws/rhel-9.1-nightly-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-044006978614b7d8d"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-9.2-nightly-aarch64/main.tf
+++ b/aws/rhel-9.2-nightly-aarch64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0e6bb8c0f5920eb24"
   instance_types   = ["c7g.large", "c6g.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }

--- a/aws/rhel-9.2-nightly-x86_64/main.tf
+++ b/aws/rhel-9.2-nightly-x86_64/main.tf
@@ -5,6 +5,11 @@ module "aws" {
   ami              = "ami-0b8c9fa46efa586f8"
   instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
   internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
 }
 
 variable "internal_network" {
@@ -15,4 +20,34 @@ variable "internal_network" {
 
 output "ip_address" {
   value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
 }


### PR DESCRIPTION
In order to be able to perform fine grained analytics on our AWS budget (e.g monitor closely our CI usage). This commit brings up new tags to categorize what are each instance used for. For backward compatibility, these variables hold a default value of "unset" which means that integrating this commit will not break the CI or other tool relying on these terraforming scripts.