### PR TITLE
rhos-01: change fedora-37 flavor to "ci"

### DIFF
--- a/rhos-01/fedora-37-x86_64-large/main.tf
+++ b/rhos-01/fedora-37-x86_64-large/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "fedora-37"
   image_id  = "edeb1b44-b086-4e61-9648-a801cc098027"
-  flavor_id = "c3ec7a0a-0443-4253-a6ab-040cc0278ced"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 
 output "ip_address" {

--- a/rhos-01/fedora-37-x86_64/main.tf
+++ b/rhos-01/fedora-37-x86_64/main.tf
@@ -3,7 +3,7 @@ module "openstack" {
 
   name      = "fedora-37"
   image_id  = "edeb1b44-b086-4e61-9648-a801cc098027"
-  flavor_id = "f2c4469b-f516-46d1-8b87-1dcca68fb3d9"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 
 output "ip_address" {


### PR DESCRIPTION
Fedora-37 was using "ci-ssd" machines but these do not support nested kvm which is necessary for our CI. Changing to "ci" enables the use of nested kvm.