### PR TITLE
Rebalance spot instance types

### DIFF
--- a/aws/centos-stream-8-aarch64/main.tf
+++ b/aws/centos-stream-8-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-8-aarch64"
   ami              = "ami-0a311be1169cd6581"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/centos-stream-8-x86_64/main.tf
+++ b/aws/centos-stream-8-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-8-x86_64"
   ami              = "ami-059f1cc52e6c85908"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/centos-stream-9-aarch64/main.tf
+++ b/aws/centos-stream-9-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-9-aarch64"
   ami              = "ami-08751d099be28f086"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/centos-stream-9-x86_64/main.tf
+++ b/aws/centos-stream-9-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-9-x86_64"
   ami              = "ami-0ac40768a045a5f2b"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-35-aarch64/main.tf
+++ b/aws/fedora-35-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-35-aarch64"
   ami              = "ami-068c123e1c1ca0d49"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-35-x86_64/main.tf
+++ b/aws/fedora-35-x86_64/main.tf
@@ -7,7 +7,7 @@ module "aws" {
   # Fedora 35 AMI doesn't boot on c6i.large, let's use only AMD
   # See: https://pagure.io/cloud-sig/issue/359
   # TODO for Fedora 36: add c6i.large for more options
-  instance_types   = ["c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-36-aarch64/main.tf
+++ b/aws/fedora-36-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-36-aarch64"
   ami              = "ami-01925eb0821988986"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-36-x86_64/main.tf
+++ b/aws/fedora-36-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-36-x86_64"
   ami              = "ami-08b7bda26f4071b80"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-37-aarch64/main.tf
+++ b/aws/fedora-37-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-37-aarch64"
   ami              = "ami-01bd3f31f182f38fc"
-  instance_types   = ["c7g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/fedora-37-x86_64/main.tf
+++ b/aws/fedora-37-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-37-x86_64"
   ami              = "ami-0bebd838a57335c31"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.4-ga-aarch64/main.tf
+++ b/aws/rhel-8.4-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.4-ga-aarch64"
   ami              = "ami-0297f1f9bad64fa3d"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.4-ga-x86_64/main.tf
+++ b/aws/rhel-8.4-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.4-ga-x86_64"
   ami              = "ami-0ae9702360611e715"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.5-ga-aarch64/main.tf
+++ b/aws/rhel-8.5-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.5-ga-aarch64"
   ami              = "ami-06bbacb93891d7356"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.5-ga-x86_64/main.tf
+++ b/aws/rhel-8.5-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.5-ga-x86_64"
   ami              = "ami-06f1e6f8b3457ae7c"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.6-ga-aarch64/main.tf
+++ b/aws/rhel-8.6-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.6-ga-aarch64"
   ami              = "ami-0238411fb452f8275"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.6-ga-x86_64/main.tf
+++ b/aws/rhel-8.6-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.6-ga-x86_64"
   ami              = "ami-06640050dc3f556bb"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.7-nightly-aarch64/main.tf
+++ b/aws/rhel-8.7-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.7-nightly-aarch64"
   ami              = "ami-0d13b40991f03cc46"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.7-nightly-x86_64/main.tf
+++ b/aws/rhel-8.7-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.7-nightly-x86_64"
   ami              = "ami-0e85834babf34f9f1"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.8-nightly-aarch64/main.tf
+++ b/aws/rhel-8.8-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.8-nightly-aarch64"
   ami              = "ami-028ae4e81828fd7a9"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-8.8-nightly-x86_64/main.tf
+++ b/aws/rhel-8.8-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.8-nightly-x86_64"
   ami              = "ami-02ae1f6cd70c7b0b8"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.0-ga-aarch64/main.tf
+++ b/aws/rhel-9.0-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.0-ga-aarch64"
   ami              = "ami-08ddbe20d7e0d2f8f"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.0-ga-x86_64/main.tf
+++ b/aws/rhel-9.0-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.0-ga-x86_64"
   ami              = "ami-0c41531b8d18cc72b"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.1-nightly-aarch64/main.tf
+++ b/aws/rhel-9.1-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.1-nightly-aarch64"
   ami              = "ami-0d2f9b81e9ec5778e"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.1-nightly-x86_64/main.tf
+++ b/aws/rhel-9.1-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.1-nightly-x86_64"
   ami              = "ami-044006978614b7d8d"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.2-nightly-aarch64/main.tf
+++ b/aws/rhel-9.2-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.2-nightly-aarch64"
   ami              = "ami-0e6bb8c0f5920eb24"
-  instance_types   = ["c7g.large", "c6g.large"]
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
 }
 

--- a/aws/rhel-9.2-nightly-x86_64/main.tf
+++ b/aws/rhel-9.2-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.2-nightly-x86_64"
   ami              = "ami-0b8c9fa46efa586f8"
-  instance_types   = ["c6i.large", "c6a.large", "c5.large", "c5a.large"]
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
 }
 


### PR DESCRIPTION
According to https://aws.amazon.com/ec2/spot/instance-advisor/, we used instance types that are currently prone to being killed quickly. Let's take data from the analyzer and use only instances that have the lowest probability.