### PR TITLE
Use RHEL CloudAccess images and add 8.7 and 9.1

### DIFF
--- a/aws/rhel-8.6-ga-aarch64/main.tf
+++ b/aws/rhel-8.6-ga-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "rhel-8.6-ga-aarch64"
-  ami              = "ami-0238411fb452f8275"
+  ami              = "ami-0c84d76d81209a0e2"
   instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/aws/rhel-8.6-ga-x86_64/main.tf
+++ b/aws/rhel-8.6-ga-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "rhel-8.6-ga-x86_64"
-  ami              = "ami-06640050dc3f556bb"
+  ami              = "ami-03debf3ebf61b20cd"
   instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/aws/rhel-8.7-ga-aarch64/config.json
+++ b/aws/rhel-8.7-ga-aarch64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "aarch64",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-8.7-ga-aarch64/main.tf
+++ b/aws/rhel-8.7-ga-aarch64/main.tf
@@ -1,0 +1,53 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-8.7-ga-aarch64"
+  ami              = "ami-0821323c71bdeb2c8"
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
+}

--- a/aws/rhel-8.7-ga-x86_64/config.json
+++ b/aws/rhel-8.7-ga-x86_64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "amd64",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-8.7-ga-x86_64/main.tf
+++ b/aws/rhel-8.7-ga-x86_64/main.tf
@@ -1,0 +1,53 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-8.7-ga-x86_64"
+  ami              = "ami-0f5b9c5759eda22b8"
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
+}

--- a/aws/rhel-9.0-ga-aarch64/main.tf
+++ b/aws/rhel-9.0-ga-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "rhel-9.0-ga-aarch64"
-  ami              = "ami-08ddbe20d7e0d2f8f"
+  ami              = "ami-0c995d4b2fa7b5651"
   instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/aws/rhel-9.0-ga-x86_64/main.tf
+++ b/aws/rhel-9.0-ga-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "rhel-9.0-ga-x86_64"
-  ami              = "ami-0c41531b8d18cc72b"
+  ami              = "ami-0bb9a0709deadd211"
   instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/aws/rhel-9.1-ga-aarch64/config.json
+++ b/aws/rhel-9.1-ga-aarch64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "aarch64",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-9.1-ga-aarch64/main.tf
+++ b/aws/rhel-9.1-ga-aarch64/main.tf
@@ -1,0 +1,53 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-9.1-ga-aarch64"
+  ami              = "ami-022874176058d7ad5"
+  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
+}

--- a/aws/rhel-9.1-ga-x86_64/config.json
+++ b/aws/rhel-9.1-ga-x86_64/config.json
@@ -1,0 +1,5 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "amd64",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-9.1-ga-x86_64/main.tf
+++ b/aws/rhel-9.1-ga-x86_64/main.tf
@@ -1,0 +1,53 @@
+module "aws" {
+  source = "../_base"
+
+  name             = "rhel-9.1-ga-x86_64"
+  ami              = "ami-0ffe242fc69b3b277"
+  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  internal_network = var.internal_network
+  job_name         = var.job_name
+  project          = var.project
+  branch           = var.branch
+  pipeline_id      = var.pipeline_id
+  pipeline_source  = var.pipeline_source
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
+}


### PR DESCRIPTION
2 commits:

### aws/rhel-*-ga-*: Use Cloud Access images

We used PAYG before, so I actually believe we paid for RHEL. Switch to the
Cloud Access images that are free for us.

See the relevant documentation change:
https://gitlab.cee.redhat.com/osbuild/internal-guides/-/merge_requests/148

### aws: add RHEL 8.7 and 9.1 GA