### PR TITLE
update Fedora 37 images to the GA ones

### DIFF
--- a/aws/fedora-37-aarch64/config.json
+++ b/aws/fedora-37-aarch64/config.json
@@ -1,5 +1,4 @@
 {
     "user": "fedora",
-    "runnerArch": "aarch64",
-    "prepareScript": "sudo rm -rf /etc/yum.repos.d/*.repo"
+    "runnerArch": "aarch64"
 }

--- a/aws/fedora-37-aarch64/main.tf
+++ b/aws/fedora-37-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "fedora-37-aarch64"
-  ami              = "ami-01bd3f31f182f38fc"
+  ami              = "ami-0e9221491fc51fca6"
   instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/aws/fedora-37-x86_64/config.json
+++ b/aws/fedora-37-x86_64/config.json
@@ -1,5 +1,4 @@
 {
     "user": "fedora",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -rf /etc/yum.repos.d/*.repo"
+    "runnerArch": "amd64"
 }

--- a/aws/fedora-37-x86_64/main.tf
+++ b/aws/fedora-37-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "fedora-37-x86_64"
-  ami              = "ami-0bebd838a57335c31"
+  ami              = "ami-023fb534213ca41da"
   instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/rhos-01/fedora-37-x86_64-large/config.json
+++ b/rhos-01/fedora-37-x86_64-large/config.json
@@ -1,5 +1,4 @@
 {
     "user": "fedora",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -rf /etc/yum.repos.d/*.repo"
+    "runnerArch": "amd64"
 }

--- a/rhos-01/fedora-37-x86_64-large/main.tf
+++ b/rhos-01/fedora-37-x86_64-large/main.tf
@@ -2,7 +2,7 @@ module "openstack" {
   source = "../_base"
 
   name      = "fedora-37"
-  image_id  = "edeb1b44-b086-4e61-9648-a801cc098027"
+  image_id  = "bcc4bb14-db29-4a46-8927-404536e002be"
   flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 

--- a/rhos-01/fedora-37-x86_64/config.json
+++ b/rhos-01/fedora-37-x86_64/config.json
@@ -1,5 +1,4 @@
 {
     "user": "fedora",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -rf /etc/yum.repos.d/*.repo"
+    "runnerArch": "amd64"
 }

--- a/rhos-01/fedora-37-x86_64/main.tf
+++ b/rhos-01/fedora-37-x86_64/main.tf
@@ -2,7 +2,7 @@ module "openstack" {
   source = "../_base"
 
   name      = "fedora-37"
-  image_id  = "edeb1b44-b086-4e61-9648-a801cc098027"
+  image_id  = "bcc4bb14-db29-4a46-8927-404536e002be"
   flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 


### PR DESCRIPTION
Which also means that we don't need the prepareScript hack anymore! \o/

The hack was there due to the fact that our CI code cannot override testing repositories that are enabled in pre-GA images by default.