### PR TITLE
base: 4h timeout on the spot fleet request

### DIFF
--- a/aws/_base/main.tf
+++ b/aws/_base/main.tf
@@ -20,6 +20,7 @@ resource "aws_spot_fleet_request" "runner" {
   target_capacity                     = 1
   wait_for_fulfillment                = "true"
   terminate_instances_with_expiration = "true"
+  valid_until                         = timeadd(timestamp(), "4h")
 
   dynamic "launch_specification" {
     for_each = setproduct(var.instance_types, var.internal_network ? local.internal_subnets : local.external_subnets)


### PR DESCRIPTION
We have a lot of leftovers after CI has run. We need to find a way to automatically remove outdated EC2 fleet instances. Valid_until is a variable that if set will timeout the request. With the combination of "terminate_instances_with_expiration" it should correctly kill the instance when the 4h mark is reached.