### PR TITLE
GCP: Add nightly repos to prepareScript

### DIFF
--- a/gcp/rhel-8.8-nightly-x86_64/config.json
+++ b/gcp/rhel-8.8-nightly-x86_64/config.json
@@ -1,4 +1,5 @@
 {
     "user": "cloud-user",
-    "runnerArch": "amd64"
+    "runnerArch": "amd64",
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel8internal.repo <<EOT\n[RHEL-8-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.8.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.8.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-8-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.8.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }

--- a/gcp/rhel-9.2-nightly-x86_64/config.json
+++ b/gcp/rhel-9.2-nightly-x86_64/config.json
@@ -1,4 +1,5 @@
 {
     "user": "cloud-user",
-    "runnerArch": "amd64"
+    "runnerArch": "amd64",
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
 }


### PR DESCRIPTION
Without this provisioning of the runners on nightly pipelines fail.

@atodorov This should fix the issue with provisioning of these runners on the nightly scheduled pipelines.