### PR TITLE
aws: reupload deleted centos-stream-9 images

### DIFF
--- a/aws/centos-stream-9-aarch64/main.tf
+++ b/aws/centos-stream-9-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "centos-stream-9-aarch64"
-  ami              = "ami-071eb93df3cfe5101"
+  ami              = "ami-0a3c915c9bc95e912"
   instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/aws/centos-stream-9-x86_64/main.tf
+++ b/aws/centos-stream-9-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "centos-stream-9-x86_64"
-  ami              = "ami-09be5028b49e0505a"
+  ami              = "ami-03b0e68987a8899ca"
   instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
   job_name         = var.job_name


### PR DESCRIPTION
For some reason the images we used before are gone so I created new ones using image builder service.