### PR TITLE
COMPOSER-1959: Update 8.9 aarch64 AMI to RHEL-8.9.0-20230503.20

### DIFF
--- a/aws/rhel-8.9-nightly-aarch64/main.tf
+++ b/aws/rhel-8.9-nightly-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "rhel-8.9-nightly-aarch64"
-  ami              = "ami-0b35637e12ef38576"
+  ami              = "ami-0f943fa3e140fe2da"
   instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name


### PR DESCRIPTION
previously imported AMI was aarch64 but incorrectly tagged as x86_64 leading to failures when launching VMs from it.