### PR TITLE
rhos-01/centos-stream-8-x86_64: update to more recent compose

### DIFF
--- a/rhos-01/centos-stream-8-x86_64-large/main.tf
+++ b/rhos-01/centos-stream-8-x86_64-large/main.tf
@@ -2,7 +2,7 @@ module "openstack" {
   source = "../_base"
 
   name      = "centos-stream-8"
-  image_id  = "0285b667-3d71-4e8d-a66d-a0442bae9116"
+  image_id  = "9713349e-6f77-4302-b404-1d5a7df714de"
   flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 

--- a/rhos-01/centos-stream-8-x86_64/main.tf
+++ b/rhos-01/centos-stream-8-x86_64/main.tf
@@ -2,7 +2,7 @@ module "openstack" {
   source = "../_base"
 
   name      = "centos-stream-8"
-  image_id  = "0285b667-3d71-4e8d-a66d-a0442bae9116"
+  image_id  = "9713349e-6f77-4302-b404-1d5a7df714de"
   flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 


### PR DESCRIPTION
This build has a newer kernel which includes support for `LOOP_CONFIGURE`.

https://bugzilla.redhat.com/show_bug.cgi?id=1881760

https://github.com/osbuild/osbuild/commit/da11ef4eb014c22f425a2ecfebc2d260f8d95ee9