### PR TITLE
rhos-01/centos-stream-8-x86_64: include correct architecture

### DIFF
--- a/rhos-01/centos-stream-8-x86_64-large/main.tf
+++ b/rhos-01/centos-stream-8-x86_64-large/main.tf
@@ -2,7 +2,7 @@ module "openstack" {
   source = "../_base"
 
   name      = "centos-stream-8"
-  image_id  = "9713349e-6f77-4302-b404-1d5a7df714de"
+  image_id  = "cbdaa1f7-f12d-4e7c-b4c0-43a3346c6278"
   flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 

--- a/rhos-01/centos-stream-8-x86_64/main.tf
+++ b/rhos-01/centos-stream-8-x86_64/main.tf
@@ -2,7 +2,7 @@ module "openstack" {
   source = "../_base"
 
   name      = "centos-stream-8"
-  image_id  = "9713349e-6f77-4302-b404-1d5a7df714de"
+  image_id  = "cbdaa1f7-f12d-4e7c-b4c0-43a3346c6278"
   flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 


### PR DESCRIPTION
The previous image didn't have the correct architecture set.

---

https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/pipelines/877555943 this one worked :)