### PR TITLE
aws: Update centos-stream-8 images

### DIFF
--- a/aws/centos-stream-8-aarch64/config.json
+++ b/aws/centos-stream-8-aarch64/config.json
@@ -1,4 +1,4 @@
 {
-    "user": "centos",
+    "user": "ec2-user",
     "runnerArch": "aarch64"
 }

--- a/aws/centos-stream-8-aarch64/main.tf
+++ b/aws/centos-stream-8-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "centos-stream-8-aarch64"
-  ami              = "ami-0a311be1169cd6581"
+  ami              = "ami-0d5d5186951d0f2bf"
   instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/aws/centos-stream-8-x86_64/config.json
+++ b/aws/centos-stream-8-x86_64/config.json
@@ -1,4 +1,4 @@
 {
-    "user": "centos",
+    "user": "ec2-user",
     "runnerArch": "amd64"
 }

--- a/aws/centos-stream-8-x86_64/main.tf
+++ b/aws/centos-stream-8-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "centos-stream-8-x86_64"
-  ami              = "ami-059f1cc52e6c85908"
+  ami              = "ami-05008adc4f7acd8b4"
   instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network
   job_name         = var.job_name


### PR DESCRIPTION
Images were over 2 years old and were causing issues during updates in CI. Images were created by Image builder service.