### PR TITLE
Aws instance types cleanup

### DIFF
--- a/aws/_base/main.tf
+++ b/aws/_base/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 }
 
 resource "aws_spot_fleet_request" "runner" {
-  allocation_strategy = "lowestPrice"
+  allocation_strategy = "priceCapacityOptimized"
 
   fleet_type                          = "request"
   iam_fleet_role                      = local.iam_fleet_role

--- a/aws/centos-stream-8-aarch64/main.tf
+++ b/aws/centos-stream-8-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-8-aarch64"
   ami              = "ami-0d5d5186951d0f2bf"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/centos-stream-8-x86_64/main.tf
+++ b/aws/centos-stream-8-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-8-x86_64"
   ami              = "ami-05008adc4f7acd8b4"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/centos-stream-9-aarch64/main.tf
+++ b/aws/centos-stream-9-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-9-aarch64"
   ami              = "ami-0a3c915c9bc95e912"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/centos-stream-9-x86_64/main.tf
+++ b/aws/centos-stream-9-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "centos-stream-9-x86_64"
   ami              = "ami-03b0e68987a8899ca"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-35-aarch64/main.tf
+++ b/aws/fedora-35-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-35-aarch64"
   ami              = "ami-068c123e1c1ca0d49"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-36-aarch64/main.tf
+++ b/aws/fedora-36-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-36-aarch64"
   ami              = "ami-01925eb0821988986"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-36-x86_64/main.tf
+++ b/aws/fedora-36-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-36-x86_64"
   ami              = "ami-08b7bda26f4071b80"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-37-aarch64/main.tf
+++ b/aws/fedora-37-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-37-aarch64"
   ami              = "ami-0e9221491fc51fca6"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-37-x86_64/main.tf
+++ b/aws/fedora-37-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-37-x86_64"
   ami              = "ami-023fb534213ca41da"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-38-aarch64/main.tf
+++ b/aws/fedora-38-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-38-aarch64"
   ami              = "ami-0da456bb338ee122b" # Fedora-Cloud-Base-38-1.6
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-38-x86_64/main.tf
+++ b/aws/fedora-38-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-38-x86_64"
   ami              = "ami-01752495da7056fa9" # Fedora-Cloud-Base-38-1.6
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-39-aarch64/main.tf
+++ b/aws/fedora-39-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-39-aarch64"
   ami              = "ami-07c230ef2012a0ea6" # Fedora-Cloud-Base-39-20230811.n.0
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/fedora-39-x86_64/main.tf
+++ b/aws/fedora-39-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "fedora-39-x86_64"
   ami              = "ami-07c0ce2cc750048fb" # Fedora-Cloud-Base-39-20230811.n.0
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.10-nightly-aarch64/main.tf
+++ b/aws/rhel-8.10-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.10-nightly-aarch64"
   ami              = "ami-06b3b4097c6387a99"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.10-nightly-x86_64/main.tf
+++ b/aws/rhel-8.10-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.10-nightly-x86_64"
   ami              = "ami-0c7095f5c075ec4bb"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.4-ga-aarch64/main.tf
+++ b/aws/rhel-8.4-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.4-ga-aarch64"
   ami              = "ami-0297f1f9bad64fa3d"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.4-ga-x86_64/main.tf
+++ b/aws/rhel-8.4-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.4-ga-x86_64"
   ami              = "ami-0ae9702360611e715"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.5-ga-aarch64/main.tf
+++ b/aws/rhel-8.5-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.5-ga-aarch64"
   ami              = "ami-06bbacb93891d7356"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.5-ga-x86_64/main.tf
+++ b/aws/rhel-8.5-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.5-ga-x86_64"
   ami              = "ami-06f1e6f8b3457ae7c"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.6-ga-aarch64/main.tf
+++ b/aws/rhel-8.6-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.6-ga-aarch64"
   ami              = "ami-0c84d76d81209a0e2"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.6-ga-x86_64/main.tf
+++ b/aws/rhel-8.6-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.6-ga-x86_64"
   ami              = "ami-03debf3ebf61b20cd"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.7-ga-aarch64/main.tf
+++ b/aws/rhel-8.7-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.7-ga-aarch64"
   ami              = "ami-0821323c71bdeb2c8"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.7-ga-x86_64/main.tf
+++ b/aws/rhel-8.7-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.7-ga-x86_64"
   ami              = "ami-0f5b9c5759eda22b8"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.8-ga-aarch64/main.tf
+++ b/aws/rhel-8.8-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.8-ga-aarch64"
   ami              = "ami-063f3c5f5a42faba2"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.8-ga-aarch64/main.tf
+++ b/aws/rhel-8.8-ga-aarch64/main.tf
@@ -1,7 +1,7 @@
 module "aws" {
   source = "../_base"
 
-  name             = "rhel-8.8-nightly-aarch64"
+  name             = "rhel-8.8-ga-aarch64"
   ami              = "ami-063f3c5f5a42faba2"
   instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
   internal_network = var.internal_network

--- a/aws/rhel-8.8-ga-x86_64/main.tf
+++ b/aws/rhel-8.8-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.8-ga-x86_64"
   ami              = "ami-0a27787d9891cf355"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.8-ga-x86_64/main.tf
+++ b/aws/rhel-8.8-ga-x86_64/main.tf
@@ -1,7 +1,7 @@
 module "aws" {
   source = "../_base"
 
-  name             = "rhel-8.8-nightly-x86_64"
+  name             = "rhel-8.8-ga-x86_64"
   ami              = "ami-0a27787d9891cf355"
   instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
   internal_network = var.internal_network

--- a/aws/rhel-8.8-nightly-aarch64/main.tf
+++ b/aws/rhel-8.8-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.8-nightly-aarch64"
   ami              = "ami-0b4782bbe7fa75c72"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.8-nightly-x86_64/main.tf
+++ b/aws/rhel-8.8-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.8-nightly-x86_64"
   ami              = "ami-0f2ca04bc5cc4aab5"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.9-nightly-aarch64/main.tf
+++ b/aws/rhel-8.9-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.9-nightly-aarch64"
   ami              = "ami-0f943fa3e140fe2da"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-8.9-nightly-x86_64/main.tf
+++ b/aws/rhel-8.9-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-8.9-nightly-x86_64"
   ami              = "ami-071f90bdf8487b83e"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.0-ga-aarch64/main.tf
+++ b/aws/rhel-9.0-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.0-ga-aarch64"
   ami              = "ami-0c995d4b2fa7b5651"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.0-ga-x86_64/main.tf
+++ b/aws/rhel-9.0-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.0-ga-x86_64"
   ami              = "ami-0bb9a0709deadd211"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.1-ga-aarch64/main.tf
+++ b/aws/rhel-9.1-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.1-ga-aarch64"
   ami              = "ami-022874176058d7ad5"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.1-ga-x86_64/main.tf
+++ b/aws/rhel-9.1-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.1-ga-x86_64"
   ami              = "ami-0ffe242fc69b3b277"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.1-nightly-aarch64/main.tf
+++ b/aws/rhel-9.1-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.1-nightly-aarch64"
   ami              = "ami-07bfd9d679c92b63b"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.1-nightly-x86_64/main.tf
+++ b/aws/rhel-9.1-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.1-nightly-x86_64"
   ami              = "ami-0fc08c71d8e2014f4"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.2-ga-aarch64/main.tf
+++ b/aws/rhel-9.2-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.2-nightly-aarch64"
   ami              = "ami-0f443396618b72764"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.2-ga-x86_64/main.tf
+++ b/aws/rhel-9.2-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.2-nightly-x86_64"
   ami              = "ami-0b2aebaba2673ce56"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.2-nightly-aarch64/main.tf
+++ b/aws/rhel-9.2-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.2-nightly-aarch64"
   ami              = "ami-0d3e8a65b3fbba134"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.2-nightly-x86_64/main.tf
+++ b/aws/rhel-9.2-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.2-nightly-x86_64"
   ami              = "ami-0af767b754ac0d77c"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.3-nightly-aarch64/main.tf
+++ b/aws/rhel-9.3-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.3-nightly-aarch64"
   ami              = "ami-0f0936e4c473c129b"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.3-nightly-x86_64/main.tf
+++ b/aws/rhel-9.3-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.3-nightly-x86_64"
   ami              = "ami-0be81136223f0bb55"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.4-nightly-aarch64/main.tf
+++ b/aws/rhel-9.4-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.4-nightly-aarch64"
   ami              = "ami-0f31cc255cbba3042"
-  instance_types   = ["c7g.large", "c6gd.large", "m6gd.large"]
+  instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project

--- a/aws/rhel-9.4-nightly-x86_64/main.tf
+++ b/aws/rhel-9.4-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name             = "rhel-9.4-nightly-x86_64"
   ami              = "ami-006c774d6c0b73ca9"
-  instance_types   = ["m5d.large", "c5ad.large", "m5ad.large", "c5.large", "c6id.large"]
+  instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name
   project          = var.project


### PR DESCRIPTION
    aws: use general purpose instance types & drop ssd
    
    The large general purpose instance types have double the memory as
    compute optimised instances, making it less likely we see OOMs in rpm
    builds.
   

