### PR TITLE
aws: remove profile from aws provider

### DIFF
--- a/aws/_base/main.tf
+++ b/aws/_base/main.tf
@@ -8,8 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  profile = "default"
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
 resource "aws_spot_fleet_request" "runner" {


### PR DESCRIPTION
There is no credentials file specified, and terraform errors out on newer plugin versions.