### PR TITLE
Update Fedora 39 AMIs

### DIFF
--- a/aws/fedora-39-aarch64/main.tf
+++ b/aws/fedora-39-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "fedora-39-aarch64"
-  ami              = "ami-07c230ef2012a0ea6" # Fedora-Cloud-Base-39-20230811.n.0
+  ami              = "ami-02512ed66c07ef82b" # Fedora-Cloud-Base-39-20231204.0
   instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name

--- a/aws/fedora-39-x86_64/main.tf
+++ b/aws/fedora-39-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "fedora-39-x86_64"
-  ami              = "ami-07c0ce2cc750048fb" # Fedora-Cloud-Base-39-20230811.n.0
+  ami              = "ami-048e58e08c5dafb10" # Fedora-Cloud-Base-39-20231204.0
   instance_types   = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network = var.internal_network
   job_name         = var.job_name


### PR DESCRIPTION
Fixes an issue with s3cmd in Fedora 39, x86_64. For successfull job execution see https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/pipelines/1095699455 (from https://github.com/osbuild/osbuild-composer/pull/3820)