### PR TITLE
DO NOT DELETE YET: Workaround: Switch Fedora-39-aarch64 to community owned AMI

### DIFF
--- a/aws/fedora-39-aarch64/main.tf
+++ b/aws/fedora-39-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name             = "fedora-39-aarch64"
-  ami              = "ami-02512ed66c07ef82b" # Fedora-Cloud-Base-39-20231204.0
+  ami              = "ami-07cfa8c4bff3a099b" # Owner: 125523088429; Fedora-Cloud-Base-39-20231204.0
   instance_types   = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network = var.internal_network
   job_name         = var.job_name


### PR DESCRIPTION
I had copied this into our account previously however the persist=true tag probably wasn't applied properly and now the AMI is missing. At the same time the AWS console has troubles searching for "Fedora-Cloud-Base-39" (which we then use to copy the AMI) while we can still see the same AMI via the AMI Catalog page (which doesn't allow copying).

**WARNING:** used for debugging https://github.com/osbuild/osbuild-composer/pull/3820, do not remove this branch yet!