### PR TITLE
aws: allow setting an instance profile on the runner

### DIFF
--- a/aws/_base/main.tf
+++ b/aws/_base/main.tf
@@ -24,10 +24,11 @@ resource "aws_spot_fleet_request" "runner" {
   dynamic "launch_specification" {
     for_each = setproduct(var.instance_types, var.internal_network ? local.internal_subnets : local.external_subnets)
     content {
-      ami           = var.ami
-      subnet_id     = launch_specification.value[1]
-      key_name      = "gitlab-runner"
-      instance_type = launch_specification.value[0]
+      ami                  = var.ami
+      subnet_id            = launch_specification.value[1]
+      key_name             = "gitlab-runner"
+      instance_type        = launch_specification.value[0]
+      iam_instance_profile = var.iam_instance_profile
 
       vpc_security_group_ids = [
         var.internal_network ? data.aws_security_group.internal_security_group.id : data.aws_security_group.external_security_group.id

--- a/aws/_base/variables.tf
+++ b/aws/_base/variables.tf
@@ -42,3 +42,9 @@ variable "pipeline_source" {
   description = "the source that triggered the job"
   type        = string
 }
+
+variable "iam_instance_profile" {
+  description = "instance profile to attach to the runner, the profile must exist"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
The idea is to test the secure instance thing as it would be used in the service. This way we can spin up a runner which is allowed to spin up a secure instance for itself.

Required by https://github.com/osbuild/gitlab-ci-terraform-executor/pull/31