### PR TITLE
github/workflows/terraform: update to latest worker

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   terraform:
     name: 'Terraform'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Should we update to `ubuntu-latest` and not care or switch to `ubuntu-22.04` before end of standard support (April 2025)

note: `ubuntu-24.04` github-runner is still beta as of today