### PR TITLE
Update Fedora AMIs to `ci-fedora-*-refresh-01-12-2024`

### DIFF
--- a/aws/fedora-39-aarch64/main.tf
+++ b/aws/fedora-39-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name                 = "fedora-39-aarch64"
-  ami                  = "ami-042c890e0691c9207" # Fedora-Cloud-Base-39-20231204.0
+  ami                  = "ami-042c890e0691c9207"
   instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name

--- a/aws/fedora-39-x86_64/main.tf
+++ b/aws/fedora-39-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name                 = "fedora-39-x86_64"
-  ami                  = "ami-087d5d7573751e134" # Fedora-Cloud-Base-39-20231204.0
+  ami                  = "ami-087d5d7573751e134"
   instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name

--- a/aws/fedora-40-aarch64/main.tf
+++ b/aws/fedora-40-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name                 = "fedora-40-aarch64"
-  ami                  = "ami-0303e6ec7a784bad8"
+  ami                  = "ami-0f6ee3f428af7709b"
   instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name

--- a/aws/fedora-40-x86_64/main.tf
+++ b/aws/fedora-40-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name                 = "fedora-40-x86_64"
-  ami                  = "ami-0e8cd0df8d3374a24"
+  ami                  = "ami-0e741632a903deb1a"
   instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name

--- a/aws/fedora-41-aarch64/main.tf
+++ b/aws/fedora-41-aarch64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name                 = "fedora-41-aarch64"
-  ami                  = "ami-0d76caf7a259cba72"
+  ami                  = "ami-00a9a97a49e3facd7"
   instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name

--- a/aws/fedora-41-x86_64/main.tf
+++ b/aws/fedora-41-x86_64/main.tf
@@ -2,7 +2,7 @@ module "aws" {
   source = "../_base"
 
   name                 = "fedora-41-x86_64"
-  ami                  = "ami-02de9b1d487c055a0"
+  ami                  = "ami-076cc82b468929221"
   instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name


### PR DESCRIPTION
Update Fedora AMIs to the latest ones that were rebuilt by the ci-image-refresh-bot.