### PR TITLE
CI: Replace RHEL 9.5 nightly with 9.5 GA templates with placeholders

### DIFF
--- a/aws/rhel-9.5-ga-aarch64/config.json
+++ b/aws/rhel-9.5-ga-aarch64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "aarch64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-aarch64-rpms",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-9.5-ga-aarch64/main.tf
+++ b/aws/rhel-9.5-ga-aarch64/main.tf
@@ -1,9 +1,9 @@
 module "aws" {
   source = "../_base"
 
-  name                 = "rhel-9.5-nightly-x86_64"
-  ami                  = "ami-0ba70f38eda71a535"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
+  name                 = "rhel-9.5-ga-aarch64"
+  ami                  = "ami-placeholder"
+  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.5-ga-x86_64/config.json
+++ b/aws/rhel-9.5-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-9.5-ga-x86_64/main.tf
+++ b/aws/rhel-9.5-ga-x86_64/main.tf
@@ -1,9 +1,9 @@
 module "aws" {
   source = "../_base"
 
-  name                 = "rhel-9.5-nightly-aarch64"
-  ami                  = "ami-056331b8dbfc9295d"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
+  name                 = "rhel-9.5-ga-x86_64"
+  ami                  = "ami-placeholder"
+  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.5-nightly-aarch64/config.json
+++ b/aws/rhel-9.5-nightly-aarch64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "ec2-user",
-    "runnerArch": "aarch64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/aws/rhel-9.5-nightly-x86_64/config.json
+++ b/aws/rhel-9.5-nightly-x86_64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "ec2-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/gcp/rhel-9.5-ga-x86_64/config.json
+++ b/gcp/rhel-9.5-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/gcp/rhel-9.5-ga-x86_64/main.tf
+++ b/gcp/rhel-9.5-ga-x86_64/main.tf
@@ -1,6 +1,6 @@
 module "google" {
   source           = "../_base"
-  image            = "ci-rhel-9-nightly-refresh-18-07-2024"
+  image            = "placeholder"
   machine_type     = "n2-standard-4"
   internal_network = var.internal_network
 }

--- a/gcp/rhel-9.5-nightly-x86_64/config.json
+++ b/gcp/rhel-9.5-nightly-x86_64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "cloud-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/rhos-01/rhel-9.5-ga-x86_64-large/config.json
+++ b/rhos-01/rhel-9.5-ga-x86_64-large/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/rhos-01/rhel-9.5-ga-x86_64-large/main.tf
+++ b/rhos-01/rhel-9.5-ga-x86_64-large/main.tf
@@ -1,8 +1,8 @@
 module "openstack" {
   source = "../_base"
 
-  name      = "rhel-9-5-nightly-large"
-  image_id  = "f836a59c-7247-4dc9-93e2-d2209742fa33"
+  name      = "rhel-9-5-ga-large"
+  image_id  = "placeholder"
   flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 

--- a/rhos-01/rhel-9.5-ga-x86_64/config.json
+++ b/rhos-01/rhel-9.5-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/rhos-01/rhel-9.5-ga-x86_64/main.tf
+++ b/rhos-01/rhel-9.5-ga-x86_64/main.tf
@@ -1,8 +1,8 @@
 module "openstack" {
   source = "../_base"
 
-  name      = "rhel-9-5-nightly"
-  image_id  = "f836a59c-7247-4dc9-93e2-d2209742fa33"
+  name      = "rhel-9-5-ga"
+  image_id  = "placeholder"
   flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 

--- a/rhos-01/rhel-9.5-nightly-x86_64-large/config.json
+++ b/rhos-01/rhel-9.5-nightly-x86_64-large/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "cloud-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/rhos-01/rhel-9.5-nightly-x86_64/config.json
+++ b/rhos-01/rhel-9.5-nightly-x86_64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "cloud-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}


### PR DESCRIPTION
Replace RHEL 9.5 nightly templates with 9.5 GA ones that include placeholders for refresh-ci-images bot