### PR TITLE
Subscribe also RHEL nightly images

### DIFF
--- a/aws/rhel-10.0-nightly-aarch64/config.json
+++ b/aws/rhel-10.0-nightly-aarch64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "ec2-user",
     "runnerArch": "aarch64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/aws/rhel-10.0-nightly-x86_64/config.json
+++ b/aws/rhel-10.0-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "ec2-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/aws/rhel-10.1-nightly-aarch64/config.json
+++ b/aws/rhel-10.1-nightly-aarch64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "ec2-user",
     "runnerArch": "aarch64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/aws/rhel-10.1-nightly-x86_64/config.json
+++ b/aws/rhel-10.1-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "ec2-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/aws/rhel-9.6-nightly-aarch64/config.json
+++ b/aws/rhel-9.6-nightly-aarch64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "ec2-user",
     "runnerArch": "aarch64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/aws/rhel-9.6-nightly-x86_64/config.json
+++ b/aws/rhel-9.6-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "ec2-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/aws/rhel-9.7-nightly-aarch64/config.json
+++ b/aws/rhel-9.7-nightly-aarch64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "ec2-user",
     "runnerArch": "aarch64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/aws/rhel-9.7-nightly-x86_64/config.json
+++ b/aws/rhel-9.7-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "ec2-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/gcp/rhel-10.0-nightly-x86_64/config.json
+++ b/gcp/rhel-10.0-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/gcp/rhel-10.1-nightly-x86_64/config.json
+++ b/gcp/rhel-10.1-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/gcp/rhel-9.6-nightly-x86_64/config.json
+++ b/gcp/rhel-9.6-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/gcp/rhel-9.7-nightly-x86_64/config.json
+++ b/gcp/rhel-9.7-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/rhos-01/rhel-10.0-nightly-x86_64-large/config.json
+++ b/rhos-01/rhel-10.0-nightly-x86_64-large/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/rhos-01/rhel-10.0-nightly-x86_64/config.json
+++ b/rhos-01/rhel-10.0-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/rhos-01/rhel-10.1-nightly-x86_64-large/config.json
+++ b/rhos-01/rhel-10.1-nightly-x86_64-large/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/rhos-01/rhel-10.1-nightly-x86_64/config.json
+++ b/rhos-01/rhel-10.1-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/rhos-01/rhel-9.6-nightly-x86_64-large/config.json
+++ b/rhos-01/rhel-9.6-nightly-x86_64-large/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/rhos-01/rhel-9.6-nightly-x86_64/config.json
+++ b/rhos-01/rhel-9.6-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/rhos-01/rhel-9.7-nightly-x86_64-large/config.json
+++ b/rhos-01/rhel-9.7-nightly-x86_64-large/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }

--- a/rhos-01/rhel-9.7-nightly-x86_64/config.json
+++ b/rhos-01/rhel-9.7-nightly-x86_64/config.json
@@ -1,5 +1,6 @@
 {
     "user": "cloud-user",
     "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
+    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT",
+    "subscriptionNeeded": true
 }


### PR DESCRIPTION
Subscription is needed also on RHEL nightly composes, to test cross-distro image builds of older releases. For example testing that RHEL-8.10 can be built on RHEL-9.7-nightly, etc.

Related to https://issues.redhat.com/browse/RHEL-71397 and https://github.com/osbuild/osbuild-composer/pull/4651