### PR TITLE
CI: Add runners for RHEL 9.6 and 10.0 GA (HMS-8654)

### DIFF
--- a/aws/rhel-10.0-ga-aarch64/config.json
+++ b/aws/rhel-10.0-ga-aarch64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "aarch64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-10-aarch64-rpms",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-10.0-ga-aarch64/main.tf
+++ b/aws/rhel-10.0-ga-aarch64/main.tf
@@ -1,9 +1,9 @@
 module "aws" {
   source = "../_base"
 
-  name                 = "rhel-9.6-nightly-x86_64"
-  ami                  = "ami-0384f8081caef0b39"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
+  name                 = "rhel-10.0-ga-aarch64"
+  ami                  = "placeholder"
+  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.0-ga-x86_64/config.json
+++ b/aws/rhel-10.0-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-10-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-10.0-ga-x86_64/main.tf
+++ b/aws/rhel-10.0-ga-x86_64/main.tf
@@ -1,8 +1,8 @@
 module "aws" {
   source = "../_base"
 
-  name                 = "rhel-10.0-nightly-x86_64"
-  ami                  = "ami-08f43b3466934bb07"
+  name                 = "rhel-10.0-ga-x86_64"
+  ami                  = "placeholder"
   instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name

--- a/aws/rhel-10.0-nightly-aarch64/config.json
+++ b/aws/rhel-10.0-nightly-aarch64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "ec2-user",
-    "runnerArch": "aarch64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/aws/rhel-10.0-nightly-x86_64/config.json
+++ b/aws/rhel-10.0-nightly-x86_64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "ec2-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/aws/rhel-9.6-ga-aarch64/config.json
+++ b/aws/rhel-9.6-ga-aarch64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "aarch64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-aarch64-rpms",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-9.6-ga-aarch64/main.tf
+++ b/aws/rhel-9.6-ga-aarch64/main.tf
@@ -1,8 +1,8 @@
 module "aws" {
   source = "../_base"
 
-  name                 = "rhel-10.0-nightly-aarch64"
-  ami                  = "ami-01304148438b5d2cf"
+  name                 = "rhel-9.6-ga-aarch64"
+  ami                  = "placeholder"
   instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name

--- a/aws/rhel-9.6-ga-x86_64/config.json
+++ b/aws/rhel-9.6-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "ec2-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/aws/rhel-9.6-ga-x86_64/main.tf
+++ b/aws/rhel-9.6-ga-x86_64/main.tf
@@ -1,9 +1,9 @@
 module "aws" {
   source = "../_base"
 
-  name                 = "rhel-9.6-nightly-aarch64"
-  ami                  = "ami-0f18a659d8fb702b2"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large"]
+  name                 = "rhel-9.6-ga-x86_64"
+  ami                  = "placeholder"
+  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.6-nightly-aarch64/config.json
+++ b/aws/rhel-9.6-nightly-aarch64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "ec2-user",
-    "runnerArch": "aarch64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/aarch64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/aarch64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/aws/rhel-9.6-nightly-x86_64/config.json
+++ b/aws/rhel-9.6-nightly-x86_64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "ec2-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/gcp/rhel-10.0-ga-x86_64/config.json
+++ b/gcp/rhel-10.0-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-10-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/gcp/rhel-10.0-ga-x86_64/main.tf
+++ b/gcp/rhel-10.0-ga-x86_64/main.tf
@@ -1,6 +1,6 @@
 module "google" {
   source           = "../_base"
-  image            = "ci-rhel-96-nightly-refresh-14-03-2025"
+  image            = "placeholder"
   machine_type     = "n2-standard-4"
   internal_network = var.internal_network
 }

--- a/gcp/rhel-10.0-nightly-x86_64/config.json
+++ b/gcp/rhel-10.0-nightly-x86_64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "cloud-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel10internal.repo <<EOT\n[RHEL-10-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-10-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/gcp/rhel-9.6-ga-x86_64/config.json
+++ b/gcp/rhel-9.6-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/gcp/rhel-9.6-ga-x86_64/main.tf
+++ b/gcp/rhel-9.6-ga-x86_64/main.tf
@@ -1,6 +1,6 @@
 module "google" {
   source           = "../_base"
-  image            = "ci-rhel-100-nightly-refresh-14-03-2025"
+  image            = "placeholder"
   machine_type     = "n2-standard-4"
   internal_network = var.internal_network
 }

--- a/gcp/rhel-9.6-nightly-x86_64/config.json
+++ b/gcp/rhel-9.6-nightly-x86_64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "cloud-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo rm -f /etc/yum.repos.d/*.repo; sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/rhos-01/rhel-10.0-ga-x86_64-large/config.json
+++ b/rhos-01/rhel-10.0-ga-x86_64-large/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-10-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/rhos-01/rhel-10.0-ga-x86_64-large/main.tf
+++ b/rhos-01/rhel-10.0-ga-x86_64-large/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "rhel-10-0-ga-large"
+  image_id  = "placeholder"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}

--- a/rhos-01/rhel-10.0-ga-x86_64/config.json
+++ b/rhos-01/rhel-10.0-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-10-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/rhos-01/rhel-10.0-ga-x86_64/main.tf
+++ b/rhos-01/rhel-10.0-ga-x86_64/main.tf
@@ -1,8 +1,8 @@
 module "openstack" {
   source = "../_base"
 
-  name      = "rhel-9-6-nightly"
-  image_id  = "b8cd406c-b319-48e9-99b8-dc0f2ccfe78e"
+  name      = "rhel-10-0-ga"
+  image_id  = "placeholder"
   flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
 }
 

--- a/rhos-01/rhel-9.6-ga-x86_64-large/config.json
+++ b/rhos-01/rhel-9.6-ga-x86_64-large/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/rhos-01/rhel-9.6-ga-x86_64-large/main.tf
+++ b/rhos-01/rhel-9.6-ga-x86_64-large/main.tf
@@ -1,8 +1,8 @@
 module "openstack" {
   source = "../_base"
 
-  name      = "rhel-9-6-nightly-large"
-  image_id  = "b8cd406c-b319-48e9-99b8-dc0f2ccfe78e"
+  name      = "rhel-9-6-ga-large"
+  image_id  = "placeholder"
   flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
 }
 

--- a/rhos-01/rhel-9.6-ga-x86_64/config.json
+++ b/rhos-01/rhel-9.6-ga-x86_64/config.json
@@ -1,0 +1,6 @@
+{
+    "user": "cloud-user",
+    "runnerArch": "amd64",
+    "prepareScript": "sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms",
+    "subscriptionNeeded": true
+}

--- a/rhos-01/rhel-9.6-ga-x86_64/main.tf
+++ b/rhos-01/rhel-9.6-ga-x86_64/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "rhel-9-6-ga"
+  image_id  = "placeholder"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}

--- a/rhos-01/rhel-9.6-nightly-x86_64-large/config.json
+++ b/rhos-01/rhel-9.6-nightly-x86_64-large/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "cloud-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}

--- a/rhos-01/rhel-9.6-nightly-x86_64/config.json
+++ b/rhos-01/rhel-9.6-nightly-x86_64/config.json
@@ -1,5 +1,0 @@
-{
-    "user": "cloud-user",
-    "runnerArch": "amd64",
-    "prepareScript": "sudo tee /etc/yum.repos.d/rhel9internal.repo <<EOT\n[RHEL-9-NIGHTLY-BaseOS]\nname=baseos\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-AppStream]\nname=appstream\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0\n\n[RHEL-9-NIGHTLY-CRB]\nname=crb\nbaseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6.0/compose/CRB/x86_64/os/\nenabled=1\ngpgcheck=0\nEOT"
-}


### PR DESCRIPTION
Add new runners definitions with placeholders for 9.6 and 10.0 GA distros and remove their nightlies.