### PR TITLE
Re-add Fedora 42 configs

### DIFF
--- a/aws/fedora-42-aarch64/config.json
+++ b/aws/fedora-42-aarch64/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "fedora",
+    "runnerArch": "aarch64"
+}

--- a/aws/fedora-42-aarch64/main.tf
+++ b/aws/fedora-42-aarch64/main.tf
@@ -1,0 +1,60 @@
+module "aws" {
+  source = "../_base"
+
+  name                 = "fedora-42-aarch64"
+  ami                  = "ami-0ae6097ac115ef9c7"
+  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  internal_network     = var.internal_network
+  job_name             = var.job_name
+  project              = var.project
+  branch               = var.branch
+  pipeline_id          = var.pipeline_id
+  pipeline_source      = var.pipeline_source
+  iam_instance_profile = var.iam_instance_profile
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
+}
+
+variable "iam_instance_profile" {
+  description = "instance profile to attach to the runner, the profile must exist"
+  type        = string
+  default     = null
+}

--- a/aws/fedora-42-x86_64/config.json
+++ b/aws/fedora-42-x86_64/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "fedora",
+    "runnerArch": "amd64"
+}

--- a/aws/fedora-42-x86_64/main.tf
+++ b/aws/fedora-42-x86_64/main.tf
@@ -1,0 +1,60 @@
+module "aws" {
+  source = "../_base"
+
+  name                 = "fedora-42-x86_64"
+  ami                  = "ami-07946ce571896ea8b"
+  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  internal_network     = var.internal_network
+  job_name             = var.job_name
+  project              = var.project
+  branch               = var.branch
+  pipeline_id          = var.pipeline_id
+  pipeline_source      = var.pipeline_source
+  iam_instance_profile = var.iam_instance_profile
+}
+
+variable "internal_network" {
+  type        = bool
+  description = "Whether this instance should be in the internal network (default: false)."
+  default     = false
+}
+
+output "ip_address" {
+  value = module.aws.ip_address
+}
+
+variable "job_name" {
+  description = "the job_name the instance is performing"
+  type        = string
+  default     = "unset"
+}
+
+variable "project" {
+  description = "the associated project"
+  type        = string
+  default     = "unset"
+}
+
+variable "branch" {
+  description = "the associated branch"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_id" {
+  description = "the associated pipeline_id"
+  type        = string
+  default     = "unset"
+}
+
+variable "pipeline_source" {
+  description = "the source that trigger the job"
+  type        = string
+  default     = "unset"
+}
+
+variable "iam_instance_profile" {
+  description = "instance profile to attach to the runner, the profile must exist"
+  type        = string
+  default     = null
+}

--- a/rhos-01/fedora-42-x86_64-large/config.json
+++ b/rhos-01/fedora-42-x86_64-large/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "fedora",
+    "runnerArch": "amd64"
+}

--- a/rhos-01/fedora-42-x86_64-large/main.tf
+++ b/rhos-01/fedora-42-x86_64-large/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "fedora-42-large"
+  image_id  = "dd640070-e986-400e-a67e-0e599c300718"
+  flavor_id = "2c6908ed-bb2b-43c7-8f9d-de790df5a4c0"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}

--- a/rhos-01/fedora-42-x86_64/config.json
+++ b/rhos-01/fedora-42-x86_64/config.json
@@ -1,0 +1,4 @@
+{
+    "user": "fedora",
+    "runnerArch": "amd64"
+}

--- a/rhos-01/fedora-42-x86_64/main.tf
+++ b/rhos-01/fedora-42-x86_64/main.tf
@@ -1,0 +1,11 @@
+module "openstack" {
+  source = "../_base"
+
+  name      = "fedora-42"
+  image_id  = "dd640070-e986-400e-a67e-0e599c300718"
+  flavor_id = "bca7d8ab-b1a4-4883-b4c6-a9536d51ebdd"
+}
+
+output "ip_address" {
+  value = module.openstack.ip_address
+}


### PR DESCRIPTION
Fedora 42 is still used by most projects.  Let's keep the configs for a while longer.