### PR TITLE
aws: update instances for 2026

### DIFF
--- a/aws/centos-stream-10-aarch64/main.tf
+++ b/aws/centos-stream-10-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "centos-stream-10-aarch64"
   ami                  = "ami-0e2f489bed7b2f4a4"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/centos-stream-10-x86_64/main.tf
+++ b/aws/centos-stream-10-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "centos-stream-10-x86_64"
   ami                  = "ami-01915b9c7016e264c"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/centos-stream-9-aarch64/main.tf
+++ b/aws/centos-stream-9-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "centos-stream-9-aarch64"
   ami                  = "ami-05ae5eff81e0ced6a"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/centos-stream-9-x86_64/main.tf
+++ b/aws/centos-stream-9-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "centos-stream-9-x86_64"
   ami                  = "ami-03c61ee4947de3bf6"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/fedora-42-aarch64/main.tf
+++ b/aws/fedora-42-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "fedora-42-aarch64"
   ami                  = "ami-0d36d7d651c41e445"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/fedora-42-x86_64/main.tf
+++ b/aws/fedora-42-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "fedora-42-x86_64"
   ami                  = "ami-0145515ba97037665"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/fedora-43-aarch64/main.tf
+++ b/aws/fedora-43-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "fedora-43-aarch64"
   ami                  = "ami-075f4fa74143ceb11"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/fedora-43-x86_64/main.tf
+++ b/aws/fedora-43-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "fedora-43-x86_64"
   ami                  = "ami-0f8bffe235d47a5a5"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/fedora-44-aarch64/main.tf
+++ b/aws/fedora-44-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "fedora-44-aarch64"
   ami                  = "ami-04d75a13dad415555"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/fedora-44-x86_64/main.tf
+++ b/aws/fedora-44-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "fedora-44-x86_64"
   ami                  = "ami-02d76cb24c5436fa3"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.0-ga-aarch64/main.tf
+++ b/aws/rhel-10.0-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.0-ga-aarch64"
   ami                  = "ami-0b6297ee39d69f02f"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.0-ga-x86_64/main.tf
+++ b/aws/rhel-10.0-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.0-ga-x86_64"
   ami                  = "ami-05a2e5d0246f7aa43"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.1-ga-aarch64/main.tf
+++ b/aws/rhel-10.1-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.1-ga-aarch64"
   ami                  = "ami-063291b0e878a2391"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.1-ga-x86_64/main.tf
+++ b/aws/rhel-10.1-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.1-ga-x86_64"
   ami                  = "ami-0f815923a9cd1e8c5"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.2-ga-aarch64/main.tf
+++ b/aws/rhel-10.2-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.2-ga-aarch64"
   ami                  = "ami-0902ba9da741cab3b"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.2-ga-x86_64/main.tf
+++ b/aws/rhel-10.2-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.2-ga-x86_64"
   ami                  = "ami-0fe1f42601a8c338b"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.2-nightly-aarch64/main.tf
+++ b/aws/rhel-10.2-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.2-nightly-aarch64"
   ami                  = "ami-0747d45b6cd2acb1e"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.2-nightly-x86_64/main.tf
+++ b/aws/rhel-10.2-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.2-nightly-x86_64"
   ami                  = "ami-0c551e3fd50980932"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.3-nightly-aarch64/main.tf
+++ b/aws/rhel-10.3-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.3-nightly-aarch64"
   ami                  = "ami-00c92fc740719566c"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-10.3-nightly-x86_64/main.tf
+++ b/aws/rhel-10.3-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-10.3-nightly-x86_64"
   ami                  = "ami-0ac1163ae49249c47"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.10-ga-aarch64/main.tf
+++ b/aws/rhel-8.10-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.10-ga-aarch64"
   ami                  = "ami-0431235080cdfc74e"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.10-ga-x86_64/main.tf
+++ b/aws/rhel-8.10-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.10-ga-x86_64"
   ami                  = "ami-09208d9ea9a7db98a"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.4-ga-aarch64/main.tf
+++ b/aws/rhel-8.4-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.4-ga-aarch64"
   ami                  = "ami-0297f1f9bad64fa3d"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.4-ga-x86_64/main.tf
+++ b/aws/rhel-8.4-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.4-ga-x86_64"
   ami                  = "ami-0ae9702360611e715"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.5-ga-aarch64/main.tf
+++ b/aws/rhel-8.5-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.5-ga-aarch64"
   ami                  = "ami-06bbacb93891d7356"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.5-ga-x86_64/main.tf
+++ b/aws/rhel-8.5-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.5-ga-x86_64"
   ami                  = "ami-06f1e6f8b3457ae7c"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.6-ga-aarch64/main.tf
+++ b/aws/rhel-8.6-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.6-ga-aarch64"
   ami                  = "ami-0c84d76d81209a0e2"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.6-ga-x86_64/main.tf
+++ b/aws/rhel-8.6-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.6-ga-x86_64"
   ami                  = "ami-03debf3ebf61b20cd"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.7-ga-aarch64/main.tf
+++ b/aws/rhel-8.7-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.7-ga-aarch64"
   ami                  = "ami-0821323c71bdeb2c8"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.7-ga-x86_64/main.tf
+++ b/aws/rhel-8.7-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.7-ga-x86_64"
   ami                  = "ami-0f5b9c5759eda22b8"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.8-ga-aarch64/main.tf
+++ b/aws/rhel-8.8-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.8-ga-aarch64"
   ami                  = "ami-063f3c5f5a42faba2"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.8-ga-x86_64/main.tf
+++ b/aws/rhel-8.8-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.8-ga-x86_64"
   ami                  = "ami-0a27787d9891cf355"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.9-ga-aarch64/main.tf
+++ b/aws/rhel-8.9-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.9-ga-aarch64"
   ami                  = "ami-0bf609268eeb5ab6e"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-8.9-ga-x86_64/main.tf
+++ b/aws/rhel-8.9-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-8.9-ga-x86_64"
   ami                  = "ami-0db0faf28583020fd"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.0-ga-aarch64/main.tf
+++ b/aws/rhel-9.0-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.0-ga-aarch64"
   ami                  = "ami-0c995d4b2fa7b5651"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.0-ga-x86_64/main.tf
+++ b/aws/rhel-9.0-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.0-ga-x86_64"
   ami                  = "ami-0bb9a0709deadd211"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.1-ga-aarch64/main.tf
+++ b/aws/rhel-9.1-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.1-ga-aarch64"
   ami                  = "ami-022874176058d7ad5"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.1-ga-x86_64/main.tf
+++ b/aws/rhel-9.1-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.1-ga-x86_64"
   ami                  = "ami-0ffe242fc69b3b277"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.2-ga-aarch64/main.tf
+++ b/aws/rhel-9.2-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.2-nightly-aarch64"
   ami                  = "ami-0f443396618b72764"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.2-ga-x86_64/main.tf
+++ b/aws/rhel-9.2-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.2-nightly-x86_64"
   ami                  = "ami-0b2aebaba2673ce56"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.3-ga-aarch64/main.tf
+++ b/aws/rhel-9.3-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.3-ga-aarch64"
   ami                  = "ami-0dc36ebb5ca7892f0"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.3-ga-x86_64/main.tf
+++ b/aws/rhel-9.3-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.3-ga-x86_64"
   ami                  = "ami-0b0df86dab1a3c581"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.4-ga-aarch64/main.tf
+++ b/aws/rhel-9.4-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.4-ga-aarch64"
   ami                  = "ami-0d4b45c1c46aaf25a"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.4-ga-x86_64/main.tf
+++ b/aws/rhel-9.4-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.4-ga-x86_64"
   ami                  = "ami-0a530116e4cec74c0"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.5-ga-aarch64/main.tf
+++ b/aws/rhel-9.5-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.5-ga-aarch64"
   ami                  = "ami-0cbbb083f3b4079a9"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.5-ga-x86_64/main.tf
+++ b/aws/rhel-9.5-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.5-ga-x86_64"
   ami                  = "ami-0e6c8f34e9ea19d65"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.6-ga-aarch64/main.tf
+++ b/aws/rhel-9.6-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.6-ga-aarch64"
   ami                  = "ami-0039014da034d58b7"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.6-ga-x86_64/main.tf
+++ b/aws/rhel-9.6-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.6-ga-x86_64"
   ami                  = "ami-03f03053ed3217fe8"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.7-ga-aarch64/main.tf
+++ b/aws/rhel-9.7-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.7-ga-aarch64"
   ami                  = "ami-062786140338c3459"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.7-ga-x86_64/main.tf
+++ b/aws/rhel-9.7-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.7-ga-x86_64"
   ami                  = "ami-0131f7e05c8bb0e66"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.8-ga-aarch64/main.tf
+++ b/aws/rhel-9.8-ga-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.8-ga-aarch64"
   ami                  = "ami-0ad202fc62a203d97"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.8-ga-x86_64/main.tf
+++ b/aws/rhel-9.8-ga-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.8-ga-x86_64"
   ami                  = "ami-0837aa8e656d2d444"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.8-nightly-aarch64/main.tf
+++ b/aws/rhel-9.8-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.8-nightly-aarch64"
   ami                  = "ami-0a69f6205eded2426"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.8-nightly-x86_64/main.tf
+++ b/aws/rhel-9.8-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.8-nightly-x86_64"
   ami                  = "ami-0396ee1f535e651dc"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.9-nightly-aarch64/main.tf
+++ b/aws/rhel-9.9-nightly-aarch64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.9-nightly-aarch64"
   ami                  = "ami-0c4fe8bded65a5604"
-  instance_types       = ["m6g.large", "m6gd.large", "m7g.large", "m7gd.large", "m8gd.large"]
+  instance_types       = ["m8gn.large", "im4gn.large", "m8gd.large", "r8gd.large", "i4g.large", "r7gd.large", "i8g.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project

--- a/aws/rhel-9.9-nightly-x86_64/main.tf
+++ b/aws/rhel-9.9-nightly-x86_64/main.tf
@@ -3,7 +3,7 @@ module "aws" {
 
   name                 = "rhel-9.9-nightly-x86_64"
   ami                  = "ami-0578c92636ae32d58"
-  instance_types       = ["m5.large", "m5d.large", "m5a.large", "m5ad.large", "m6a.large", "m6i.large", "m6id.large", "m7i.large", "m7a.large", "m7i-flex.large", "m8a.large", "m8i.large", "m8i-flex.large"]
+  instance_types       = ["t3.large", "m8i-flex.large", "m8azn.large", "m6idn.large", "m5dn.large", "t2.large", "m8id.large", "m5zn.large", "m5d.large", "r5n.large", "r5b.large", "r5a.large", "r5d.large"]
   internal_network     = var.internal_network
   job_name             = var.job_name
   project              = var.project


### PR DESCRIPTION
We have been seeing a lot of spot interruptions in the past weeks. Let's use instance types least likely to be interrupted as per the spot advisor:

https://spot-bid-advisor.s3.amazonaws.com/spot-advisor-data.json

All instances have 2 vCPUs and 8+ GiB RAM.